### PR TITLE
Revamp portfolio visual experience

### DIFF
--- a/src/app/layouts/MainLayout.tsx
+++ b/src/app/layouts/MainLayout.tsx
@@ -20,11 +20,13 @@ const MainLayout = () => {
   const isNavigating = navigation.state === 'loading';
 
   return (
-    <div className="min-h-screen bg-base-100 text-base-content transition-colors">
+    <div className="relative min-h-screen overflow-hidden bg-transparent text-base-content transition-colors">
+      <div className="pointer-events-none absolute inset-0 -z-20 bg-mesh-gradient" aria-hidden="true" />
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-grid-slate bg-[length:24px_24px] opacity-30" aria-hidden="true" />
       <ScrollProgressBar />
       <Navbar />
       <Sidebar />
-      <main className="relative mx-auto flex min-h-[70vh] max-w-6xl flex-1 flex-col px-4 pb-20 pt-24 md:px-8">
+      <main className="relative mx-auto flex min-h-[70vh] w-full max-w-6xl flex-1 flex-col px-4 pb-20 pt-28 md:px-8">
         {isNavigating && <Loader overlay message="Actualizando sección..." />}
         <div className={isNavigating ? 'pointer-events-none opacity-50' : ''}>
           <Outlet />

--- a/src/features/posts/components/PostCard.tsx
+++ b/src/features/posts/components/PostCard.tsx
@@ -13,7 +13,7 @@ interface PostCardProps {
 const PostCard = ({ post }: PostCardProps): JSX.Element => {
   return (
     <Reveal>
-      <Card className="flex h-full flex-col gap-5">
+      <Card className="flex h-full flex-col gap-5 border-white/30 bg-white/45 shadow-glow dark:border-white/10 dark:bg-white/5">
         <div className="flex items-center justify-between text-sm text-base-content/60">
           <span>{formatDate(post.publishedAt)}</span>
           <span>{post.readingTime}</span>
@@ -24,7 +24,7 @@ const PostCard = ({ post }: PostCardProps): JSX.Element => {
         </div>
         <div className="flex flex-wrap gap-2">
           {post.tags.map((tag) => (
-            <span key={tag} className="badge badge-sm badge-primary/80 bg-primary/10">
+            <span key={tag} className="badge badge-sm border border-primary/30 bg-primary/10 text-primary">
               {tag}
             </span>
           ))}

--- a/src/features/posts/components/PostDetail.tsx
+++ b/src/features/posts/components/PostDetail.tsx
@@ -19,7 +19,7 @@ const PostDetail = ({ post }: PostDetailProps): JSX.Element => {
         <h1 className="text-4xl font-bold text-base-content lg:text-5xl">{post.title}</h1>
         <div className="flex flex-wrap gap-2">
           {post.tags.map((tag) => (
-            <span key={tag} className="badge badge-primary/80 bg-primary/10">
+            <span key={tag} className="badge border border-primary/30 bg-primary/10 text-primary">
               {tag}
             </span>
           ))}

--- a/src/features/posts/components/PostList.tsx
+++ b/src/features/posts/components/PostList.tsx
@@ -9,7 +9,7 @@ interface PostListProps {
 const PostList = ({ posts }: PostListProps): JSX.Element => {
   if (!posts.length) {
     return (
-      <div className="rounded-2xl border border-dashed border-base-300 bg-base-200/60 p-10 text-center">
+      <div className="rounded-3xl border border-dashed border-white/30 bg-white/40 p-10 text-center text-base-content shadow-glow backdrop-blur dark:border-white/10 dark:bg-white/5">
         <p className="text-base font-medium text-base-content/70">Aún no hay artículos disponibles.</p>
       </div>
     );

--- a/src/features/posts/pages/PostDetailPage.tsx
+++ b/src/features/posts/pages/PostDetailPage.tsx
@@ -52,7 +52,9 @@ const PostDetailPage = (): JSX.Element => {
       <Link to="/posts" className={buttonStyles('ghost', 'sm')}>
         ← Ver más artículos
       </Link>
-      <PostDetail post={selectedPost} />
+      <div className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 p-8 text-base-content shadow-glow backdrop-blur-xl dark:border-white/10 dark:bg-white/10">
+        <PostDetail post={selectedPost} />
+      </div>
     </div>
   );
 };

--- a/src/features/posts/pages/PostsPage.tsx
+++ b/src/features/posts/pages/PostsPage.tsx
@@ -35,11 +35,14 @@ const PostsPage = (): JSX.Element => {
 
   return (
     <section className="space-y-10">
-      <header className="space-y-3">
-        <h1 className="text-4xl font-bold text-base-content">Ideas y aprendizajes</h1>
-        <p className="max-w-2xl text-base-content/70">
-          Reflexiones sobre arquitectura frontend, diseño de sistemas, accesibilidad y productividad creativa.
-        </p>
+      <header className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 px-6 py-10 text-base-content shadow-glow backdrop-blur-xl sm:px-12 dark:border-white/10 dark:bg-white/10">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-70" aria-hidden="true" />
+        <div className="space-y-3">
+          <h1 className="text-4xl font-bold text-base-content md:text-5xl">Ideas y aprendizajes</h1>
+          <p className="max-w-2xl text-base-content/70">
+            Reflexiones sobre arquitectura frontend, diseño de sistemas, accesibilidad y productividad creativa.
+          </p>
+        </div>
       </header>
 
       {error && (

--- a/src/features/projects/components/ProjectCard.tsx
+++ b/src/features/projects/components/ProjectCard.tsx
@@ -13,11 +13,11 @@ const ProjectCard = ({ project }: ProjectCardProps): JSX.Element => {
   return (
     <Reveal>
       <ScaleOnHover className="h-full">
-        <Card className="flex h-full flex-col gap-6">
+        <Card className="flex h-full flex-col gap-6 border-white/30 bg-white/45 shadow-glow dark:border-white/10 dark:bg-white/5">
           <div className="relative overflow-hidden rounded-xl">
             <img src={project.cover} alt={project.title} className="h-52 w-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
             {project.highlight && (
-              <span className="absolute left-4 top-4 rounded-full bg-base-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+              <span className="absolute left-4 top-4 rounded-full border border-primary/40 bg-primary/15 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary shadow-glow">
                 {project.highlight}
               </span>
             )}
@@ -29,7 +29,7 @@ const ProjectCard = ({ project }: ProjectCardProps): JSX.Element => {
             </div>
             <div className="flex flex-wrap gap-2">
               {project.technologies.map((tech) => (
-                <span key={tech} className="badge badge-outline badge-sm">
+                <span key={tech} className="badge badge-outline badge-sm border-primary/30 text-primary">
                   {tech}
                 </span>
               ))}

--- a/src/features/projects/components/ProjectList.tsx
+++ b/src/features/projects/components/ProjectList.tsx
@@ -9,10 +9,8 @@ interface ProjectListProps {
 const ProjectList = ({ projects }: ProjectListProps): JSX.Element => {
   if (!projects.length) {
     return (
-      <div className="rounded-2xl border border-dashed border-base-300 bg-base-200/60 p-10 text-center">
-        <p className="text-base font-medium text-base-content/70">
-          Aún no hay proyectos publicados. Vuelve pronto ✨
-        </p>
+      <div className="rounded-3xl border border-dashed border-white/30 bg-white/40 p-10 text-center text-base-content shadow-glow backdrop-blur dark:border-white/10 dark:bg-white/5">
+        <p className="text-base font-medium text-base-content/70">Aún no hay proyectos publicados. Vuelve pronto ✨</p>
       </div>
     );
   }

--- a/src/features/projects/pages/ProjectsPage.tsx
+++ b/src/features/projects/pages/ProjectsPage.tsx
@@ -39,26 +39,36 @@ const ProjectsPage = (): JSX.Element => {
 
   return (
     <section className="space-y-12">
-      <header className="space-y-4">
-        <h1 className="text-4xl font-bold text-base-content">Proyectos destacados</h1>
-        <p className="max-w-2xl text-lg text-base-content/70">
-          Explora productos diseñados end-to-end: arquitectura, diseño de interacción, integración con APIs y despliegues
-          automatizados. Cada proyecto está pensado para ser escalable y mantener una experiencia impecable.
-        </p>
+      <header className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 px-6 py-10 text-base-content shadow-glow backdrop-blur-xl sm:px-12 dark:border-white/10 dark:bg-white/10">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-70" aria-hidden="true" />
+        <div className="space-y-4">
+          <h1 className="text-4xl font-bold text-base-content md:text-5xl">Proyectos destacados</h1>
+          <p className="max-w-3xl text-lg text-base-content/70">
+            Explora productos diseñados end-to-end: arquitectura, research, interacción y despliegues automatizados. Cada proyecto equilibra narrativa, performance y negocio.
+          </p>
+        </div>
       </header>
 
       {featured.length > 0 && (
         <div className="space-y-6">
-          <h2 className="text-2xl font-semibold text-base-content">Selección curada</h2>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <h2 className="text-2xl font-semibold text-base-content">Selección curada</h2>
+            <p className="max-w-2xl text-sm text-base-content/60">
+              Conceptos que impulsaron métricas clave: onboarding sin fricción, dashboards accionables y experiencias que conectan con la marca.
+            </p>
+          </div>
           <ProjectList projects={featured} />
         </div>
       )}
 
       <div className="space-y-6">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-2xl font-semibold text-base-content">Todos los proyectos</h2>
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-base-content">Todos los proyectos</h2>
+            <p className="text-sm text-base-content/60">Filtra con el buscador global para encontrar tecnologías o industrias específicas.</p>
+          </div>
           {query && (
-            <span className="badge badge-lg badge-outline">
+            <span className="rounded-full border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium text-primary shadow-glow">
               {filteredProjects.length} resultados para “{query}”
             </span>
           )}

--- a/src/features/skills/components/SkillBadge.tsx
+++ b/src/features/skills/components/SkillBadge.tsx
@@ -16,13 +16,13 @@ const SkillBadge = ({ skill }: SkillBadgeProps): JSX.Element => {
   return (
     <Reveal>
       <Float amplitude={6} duration={5000}>
-        <div className="group flex h-full flex-col rounded-3xl border border-base-200 bg-base-100/80 p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-primary/20">
+        <div className="group flex h-full flex-col rounded-3xl border border-white/25 bg-white/40 p-6 text-base-content shadow-glow transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:bg-primary/10 dark:border-white/10 dark:bg-white/5">
           <div className="flex items-center justify-between gap-4">
             <h3 className="text-xl font-semibold text-base-content">{skill.name}</h3>
             <span className={`badge ${levelColors[skill.level]}`}>{skill.level}</span>
           </div>
           <p className="mt-4 text-base-content/70">{skill.description}</p>
-          <span className="mt-6 inline-flex w-fit rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+          <span className="mt-6 inline-flex w-fit rounded-full bg-primary/15 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
             {skill.category}
           </span>
         </div>

--- a/src/features/skills/components/SkillsGrid.tsx
+++ b/src/features/skills/components/SkillsGrid.tsx
@@ -9,7 +9,7 @@ interface SkillsGridProps {
 const SkillsGrid = ({ skills }: SkillsGridProps): JSX.Element => {
   if (!skills.length) {
     return (
-      <div className="rounded-2xl border border-dashed border-base-300 bg-base-200/60 p-10 text-center">
+      <div className="rounded-3xl border border-dashed border-white/30 bg-white/40 p-10 text-center text-base-content shadow-glow backdrop-blur dark:border-white/10 dark:bg-white/5">
         <p className="text-base font-medium text-base-content/70">Pronto agregaré nuevas habilidades a esta colección.</p>
       </div>
     );

--- a/src/features/skills/pages/SkillsPage.tsx
+++ b/src/features/skills/pages/SkillsPage.tsx
@@ -24,12 +24,14 @@ const SkillsPage = (): JSX.Element => {
 
   return (
     <section className="space-y-10">
-      <header className="space-y-3">
-        <h1 className="text-4xl font-bold text-base-content">Mapa de habilidades</h1>
-        <p className="max-w-2xl text-base-content/70">
-          Una mirada a las tecnologías y procesos con los que disfruto construir productos. Desde ingeniería frontend hasta
-          diseño centrado en las personas.
-        </p>
+      <header className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 px-6 py-10 text-base-content shadow-glow backdrop-blur-xl sm:px-12 dark:border-white/10 dark:bg-white/10">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-70" aria-hidden="true" />
+        <div className="space-y-3">
+          <h1 className="text-4xl font-bold text-base-content md:text-5xl">Mapa de habilidades</h1>
+          <p className="max-w-2xl text-base-content/70">
+            Tecnologías, frameworks y rituales que sostienen cada proyecto. Desde arquitectura frontend hasta research continuo.
+          </p>
+        </div>
       </header>
 
       {error && (
@@ -38,10 +40,10 @@ const SkillsPage = (): JSX.Element => {
         </div>
       )}
 
-      <div className="space-y-8">
+      <div className="space-y-10">
         {Object.entries(groupedSkills).map(([category, categorySkills]) => (
-          <div key={category} className="space-y-4">
-            <div className="flex items-center justify-between">
+          <div key={category} className="space-y-4 rounded-[2rem] border border-white/20 bg-white/40 p-6 text-base-content shadow-glow backdrop-blur dark:border-white/10 dark:bg-white/5">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <h2 className="text-2xl font-semibold text-base-content">{category}</h2>
               <span className="text-sm text-base-content/60">{categorySkills.length} skills</span>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -14,36 +14,39 @@ body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   min-height: 100vh;
   position: relative;
-  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(249, 115, 22, 0.12), transparent 60%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.02) 0%, rgba(255, 255, 255, 0) 40%);
+  background-color: #050b1a;
+  background-image:
+    radial-gradient(circle at 12% 18%, rgba(124, 58, 237, 0.32), transparent 58%),
+    radial-gradient(circle at 82% 8%, rgba(34, 211, 238, 0.26), transparent 52%),
+    radial-gradient(circle at 50% 92%, rgba(249, 115, 22, 0.22), transparent 55%),
+    linear-gradient(160deg, rgba(15, 23, 42, 0.6) 0%, rgba(15, 23, 42, 0) 42%);
 }
 
 body::before,
 body::after {
   content: '';
   position: fixed;
-  width: 520px;
-  height: 520px;
+  width: 480px;
+  height: 480px;
   border-radius: 9999px;
   filter: blur(140px);
-  opacity: 0.35;
+  opacity: 0.4;
   pointer-events: none;
   z-index: -1;
-  animation: aurora 18s ease-in-out infinite;
+  animation: aurora 26s ease-in-out infinite;
 }
 
 body::before {
   top: -160px;
-  left: -120px;
-  background: radial-gradient(circle at center, rgba(79, 70, 229, 0.4), transparent 65%);
+  left: -140px;
+  background: radial-gradient(circle at center, rgba(124, 58, 237, 0.55), transparent 70%);
 }
 
 body::after {
-  bottom: -160px;
-  right: -80px;
-  background: radial-gradient(circle at center, rgba(251, 191, 36, 0.45), transparent 60%);
-  animation-delay: 6s;
+  bottom: -180px;
+  right: -120px;
+  background: radial-gradient(circle at center, rgba(34, 211, 238, 0.45), transparent 65%);
+  animation-delay: 8s;
 }
 
 a {
@@ -55,38 +58,57 @@ a {
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-base-200;
+  @apply bg-midnightMuted;
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-primary/60 rounded-full;
+  @apply rounded-full bg-primary/60;
+}
+
+[data-theme='lumen'] body {
+  background-color: #f8fafc;
+  background-image:
+    radial-gradient(circle at 20% 10%, rgba(124, 58, 237, 0.12), transparent 55%),
+    radial-gradient(circle at 88% 12%, rgba(34, 211, 238, 0.15), transparent 65%),
+    linear-gradient(180deg, rgba(237, 233, 254, 0.4) 0%, rgba(248, 250, 252, 0) 40%);
+}
+
+[data-theme='lumen'] body::before {
+  background: radial-gradient(circle at center, rgba(124, 58, 237, 0.35), transparent 70%);
+}
+
+[data-theme='lumen'] body::after {
+  background: radial-gradient(circle at center, rgba(34, 211, 238, 0.28), transparent 65%);
+}
+
+[data-theme='dark'] body {
+  background-color: #050b1a;
+  background-image:
+    radial-gradient(circle at 12% 18%, rgba(124, 58, 237, 0.32), transparent 58%),
+    radial-gradient(circle at 82% 8%, rgba(34, 211, 238, 0.26), transparent 52%),
+    radial-gradient(circle at 50% 92%, rgba(249, 115, 22, 0.22), transparent 55%),
+    linear-gradient(160deg, rgba(15, 23, 42, 0.6) 0%, rgba(15, 23, 42, 0) 42%);
+}
+
+[data-theme='dark'] body::before {
+  background: radial-gradient(circle at center, rgba(168, 85, 247, 0.5), transparent 70%);
+}
+
+[data-theme='dark'] body::after {
+  background: radial-gradient(circle at center, rgba(34, 211, 238, 0.45), transparent 65%);
 }
 
 @keyframes aurora {
   0% {
     transform: translate3d(0, 0, 0) scale(1);
-    opacity: 0.28;
+    opacity: 0.38;
   }
   50% {
-    transform: translate3d(5%, -8%, 0) scale(1.05);
-    opacity: 0.45;
+    transform: translate3d(4%, -6%, 0) scale(1.05);
+    opacity: 0.55;
   }
   100% {
     transform: translate3d(0, 0, 0) scale(1);
-    opacity: 0.28;
+    opacity: 0.38;
   }
-}
-
-[data-theme='dark'] body {
-  background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.2), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(251, 191, 36, 0.18), transparent 60%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0) 45%);
-}
-
-[data-theme='dark'] body::before {
-  background: radial-gradient(circle at center, rgba(129, 140, 248, 0.55), transparent 65%);
-}
-
-[data-theme='dark'] body::after {
-  background: radial-gradient(circle at center, rgba(251, 191, 36, 0.35), transparent 60%);
 }

--- a/src/pages/About/AboutPage.tsx
+++ b/src/pages/About/AboutPage.tsx
@@ -3,51 +3,68 @@ import { personalInfo } from '@shared/constants/personalInfo';
 import { experienceTimeline } from '@shared/constants/timeline';
 import { Reveal } from 'react-bits';
 
+const principles = [
+  'Estrategia y narrativa conectadas a métricas',
+  'Accesibilidad diseñada desde el primer trazo',
+  'Colaboración radical con equipos multidisciplinarios',
+  'Entrega continua con diseño de sistemas vivos'
+];
+
 const AboutPage = (): JSX.Element => {
   return (
     <section className="space-y-12">
-      <header className="space-y-4">
-        <h1 className="text-4xl font-bold text-base-content">Detrás del código</h1>
-        <p className="max-w-3xl text-lg text-base-content/70">
-          {personalInfo.about.description}
-        </p>
+      <header className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 px-6 py-12 text-base-content shadow-glow backdrop-blur-xl sm:px-12 dark:border-white/10 dark:bg-white/10">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-80" aria-hidden="true" />
+        <Reveal className="space-y-5">
+          <h1 className="text-4xl font-bold text-base-content md:text-5xl">
+            Detrás del código, una visión estratégica
+          </h1>
+          <p className="max-w-3xl text-lg text-base-content/70 md:text-xl">{personalInfo.about.description}</p>
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {principles.map((principle) => (
+              <li key={principle} className="flex items-center gap-3 rounded-2xl border border-white/25 bg-white/50 px-4 py-3 text-sm text-base-content/80 dark:border-white/10 dark:bg-white/5">
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-primary via-aurora to-secondary text-xs font-semibold text-primary-foreground">
+                  ✓
+                </span>
+                {principle}
+              </li>
+            ))}
+          </ul>
+        </Reveal>
       </header>
 
       <Reveal className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
-        <Card className="space-y-4 bg-base-100/80">
+        <Card className="space-y-4 border-white/25 bg-white/50 text-base-content dark:border-white/10 dark:bg-white/5">
           <h2 className="text-2xl font-semibold text-base-content">Lo que me mueve</h2>
           <p className="text-base-content/70">
-            Creo que el mejor software se construye cuando diseño y tecnología trabajan en sincronía. Me encanta traducir
-            conversaciones complejas en experiencias intuitivas, diseñar sistemas que evolucionen en el tiempo y guiar equipos
-            hacia entregas consistentes.
+            Creo que el mejor software se construye cuando diseño y tecnología trabajan en sincronía. Me encanta traducir conversaciones complejas en experiencias intuitivas y diseñar sistemas que evolucionen en el tiempo.
           </p>
           <p className="text-base-content/70">
-            Fuera del código, me encontrarás coleccionando referencias visuales, componiendo música en sintetizadores analógicos
-            o iterando ideas en cuadernos repletos de wireframes.
+            Fuera del código, colecciono referencias visuales, compongo música en sintetizadores analógicos y lleno cuadernos con wireframes y patrones.
           </p>
         </Card>
-        <Card className="space-y-4 bg-base-100/80">
+        <Card className="space-y-4 border-white/25 bg-white/50 text-base-content dark:border-white/10 dark:bg-white/5">
           <h2 className="text-2xl font-semibold text-base-content">Manifiesto de trabajo</h2>
           <ul className="space-y-3 text-base-content/70">
-            <li>· Diseño con intención: cada componente cuenta una historia.</li>
-            <li>· Accesibilidad integrada, nunca añadida al final.</li>
-            <li>· Métricas y feedback continuo para iterar con criterio.</li>
-            <li>· Equipos empáticos que crean productos humanos.</li>
+            <li>Diseño con intención: cada componente cuenta una historia.</li>
+            <li>Accesibilidad integrada, nunca añadida al final.</li>
+            <li>Métricas y feedback continuo para iterar con criterio.</li>
+            <li>Equipos empáticos que crean productos humanos.</li>
           </ul>
         </Card>
       </Reveal>
 
       <section className="space-y-6">
-        <h2 className="text-3xl font-semibold text-base-content">Timeline de experiencia</h2>
-        <div className="space-y-4">
+        <Reveal>
+          <h2 className="text-3xl font-semibold text-base-content">Timeline de experiencia</h2>
+        </Reveal>
+        <div className="grid gap-4 lg:grid-cols-2">
           {experienceTimeline.map((item) => (
             <Reveal key={item.id}>
-              <div className="flex flex-col gap-3 rounded-3xl border border-base-200 bg-base-100/80 p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-primary/20 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <p className="text-sm uppercase tracking-wide text-primary/80">{item.period}</p>
-                  <h3 className="text-xl font-semibold text-base-content">{item.title}</h3>
-                </div>
-                <p className="max-w-3xl text-base-content/70">{item.description}</p>
+              <div className="group flex flex-col gap-3 rounded-[2rem] border border-white/20 bg-white/40 p-6 text-base-content shadow-glow transition hover:border-primary/40 hover:bg-primary/10 dark:border-white/10 dark:bg-white/5">
+                <p className="text-sm uppercase tracking-[0.3em] text-primary/80">{item.period}</p>
+                <h3 className="text-xl font-semibold text-base-content">{item.title}</h3>
+                <p className="text-base-content/70">{item.description}</p>
               </div>
             </Reveal>
           ))}

--- a/src/pages/Contact/ContactPage.tsx
+++ b/src/pages/Contact/ContactPage.tsx
@@ -42,13 +42,15 @@ const ContactPage = (): JSX.Element => {
   return (
     <section className="grid gap-10 lg:grid-cols-[1.1fr,1fr]">
       <div className="space-y-6">
-        <h1 className="text-4xl font-bold text-base-content">Construyamos algo memorable</h1>
-        <p className="text-lg text-base-content/70">
-          Cuéntame sobre tu proyecto, equipo o idea. Me interesa colaborar en productos que combinen impacto, diseño y
-          tecnología.
-        </p>
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 px-6 py-8 shadow-glow backdrop-blur-xl dark:border-white/10 dark:bg-white/10">
+          <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-70" aria-hidden="true" />
+          <h1 className="text-4xl font-bold text-base-content">Construyamos algo memorable</h1>
+          <p className="mt-3 text-lg text-base-content/70">
+            Cuéntame sobre tu proyecto, equipo o idea. Colaboremos para diseñar productos que conecten tecnología, negocio y emoción.
+          </p>
+        </div>
         <div className="grid gap-4 sm:grid-cols-2">
-          <Card className="bg-base-100/80">
+          <Card className="border-white/20 bg-white/45">
             <h2 className="text-xl font-semibold text-base-content">Servicios</h2>
             <ul className="mt-3 space-y-2 text-base-content/70">
               <li>· Consultoría en arquitectura frontend</li>
@@ -56,7 +58,7 @@ const ContactPage = (): JSX.Element => {
               <li>· Optimización de performance y accesibilidad</li>
             </ul>
           </Card>
-          <Card className="bg-base-100/80">
+          <Card className="border-white/20 bg-white/45">
             <h2 className="text-xl font-semibold text-base-content">Colaboración</h2>
             <ul className="mt-3 space-y-2 text-base-content/70">
               <li>· Equipos remotos y async</li>
@@ -67,7 +69,7 @@ const ContactPage = (): JSX.Element => {
         </div>
       </div>
 
-      <Card className="bg-base-100/80">
+      <Card className="border-white/20 bg-white/45">
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="space-y-2 text-sm font-medium text-base-content">
@@ -78,7 +80,7 @@ const ContactPage = (): JSX.Element => {
                 value={form.name}
                 onChange={handleChange}
                 required
-                className="w-full rounded-xl border border-base-300 bg-base-100 px-3 py-2 focus:border-primary focus:outline-none"
+                className="w-full rounded-xl border border-white/30 bg-white/60 px-3 py-2 text-base-content shadow-inner focus:border-primary focus:outline-none dark:border-white/10 dark:bg-white/10"
               />
             </label>
             <label className="space-y-2 text-sm font-medium text-base-content">
@@ -89,7 +91,7 @@ const ContactPage = (): JSX.Element => {
                 value={form.email}
                 onChange={handleChange}
                 required
-                className="w-full rounded-xl border border-base-300 bg-base-100 px-3 py-2 focus:border-primary focus:outline-none"
+                className="w-full rounded-xl border border-white/30 bg-white/60 px-3 py-2 text-base-content shadow-inner focus:border-primary focus:outline-none dark:border-white/10 dark:bg-white/10"
               />
             </label>
           </div>
@@ -102,7 +104,7 @@ const ContactPage = (): JSX.Element => {
                 value={form.company}
                 onChange={handleChange}
                 placeholder="Opcional"
-                className="w-full rounded-xl border border-base-300 bg-base-100 px-3 py-2 focus:border-primary focus:outline-none"
+                className="w-full rounded-xl border border-white/30 bg-white/60 px-3 py-2 text-base-content shadow-inner focus:border-primary focus:outline-none dark:border-white/10 dark:bg-white/10"
               />
             </label>
             <label className="space-y-2 text-sm font-medium text-base-content">
@@ -113,7 +115,7 @@ const ContactPage = (): JSX.Element => {
                 value={form.budget}
                 onChange={handleChange}
                 placeholder="Opcional"
-                className="w-full rounded-xl border border-base-300 bg-base-100 px-3 py-2 focus:border-primary focus:outline-none"
+                className="w-full rounded-xl border border-white/30 bg-white/60 px-3 py-2 text-base-content shadow-inner focus:border-primary focus:outline-none dark:border-white/10 dark:bg-white/10"
               />
             </label>
           </div>
@@ -125,7 +127,7 @@ const ContactPage = (): JSX.Element => {
               onChange={handleChange}
               required
               rows={5}
-              className="w-full rounded-xl border border-base-300 bg-base-100 px-3 py-2 focus:border-primary focus:outline-none"
+              className="w-full rounded-xl border border-white/30 bg-white/60 px-3 py-2 text-base-content shadow-inner focus:border-primary focus:outline-none dark:border-white/10 dark:bg-white/10"
             />
           </label>
           <Button type="submit" loading={status === 'loading'} className="w-full">

--- a/src/pages/Explore/ExplorePage.tsx
+++ b/src/pages/Explore/ExplorePage.tsx
@@ -43,11 +43,14 @@ const ExplorePage = (): JSX.Element => {
 
   return (
     <section className="space-y-10">
-      <header className="space-y-3">
-        <h1 className="text-4xl font-bold text-base-content">Explora el universo creativo</h1>
-        <p className="max-w-2xl text-base-content/70">
-          Utiliza el buscador para encontrar proyectos, artículos o habilidades específicas. Todo mi trabajo, en un solo lugar.
-        </p>
+      <header className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-white/40 px-6 py-10 text-base-content shadow-glow backdrop-blur-xl sm:px-12 dark:border-white/10 dark:bg-white/10">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-70" aria-hidden="true" />
+        <div className="space-y-3">
+          <h1 className="text-4xl font-bold text-base-content md:text-5xl">Explora el universo creativo</h1>
+          <p className="max-w-2xl text-base-content/70">
+            Utiliza el buscador para encontrar proyectos, artículos o habilidades específicas. Todo mi trabajo, en un solo lugar.
+          </p>
+        </div>
       </header>
 
       <div className="space-y-6">
@@ -59,7 +62,7 @@ const ExplorePage = (): JSX.Element => {
         </div>
         <div className="grid gap-4 md:grid-cols-2">
           {filteredProjects.map((project) => (
-            <Card key={project.id} className="flex flex-col gap-3 bg-base-100/80">
+            <Card key={project.id} className="flex flex-col gap-3 border-white/20 bg-white/45">
               <h3 className="text-xl font-semibold text-base-content">{project.title}</h3>
               <p className="text-base-content/70 line-clamp-3">{project.summary}</p>
               <Link to={`/projects/${project.id}`} className={buttonStyles('ghost', 'sm')}>
@@ -68,7 +71,7 @@ const ExplorePage = (): JSX.Element => {
             </Card>
           ))}
           {!filteredProjects.length && (
-            <Card className="bg-base-100/80 text-base-content/60">
+            <Card className="text-base-content/60">
               No encontré proyectos que coincidan {hasQuery ? `con “${query}”` : 'todavía'}.
             </Card>
           )}
@@ -84,7 +87,7 @@ const ExplorePage = (): JSX.Element => {
         </div>
         <div className="grid gap-4 md:grid-cols-2">
           {filteredPosts.map((post) => (
-            <Card key={post.id} className="flex flex-col gap-3 bg-base-100/80">
+            <Card key={post.id} className="flex flex-col gap-3 border-white/20 bg-white/45">
               <h3 className="text-xl font-semibold text-base-content">{post.title}</h3>
               <p className="text-base-content/70 line-clamp-3">{post.excerpt}</p>
               <Link to={`/posts/${post.slug}`} className={buttonStyles('ghost', 'sm')}>
@@ -93,7 +96,7 @@ const ExplorePage = (): JSX.Element => {
             </Card>
           ))}
           {!filteredPosts.length && (
-            <Card className="bg-base-100/80 text-base-content/60">No encontré artículos para esta búsqueda.</Card>
+            <Card className="text-base-content/60">No encontré artículos para esta búsqueda.</Card>
           )}
         </div>
       </div>
@@ -107,7 +110,7 @@ const ExplorePage = (): JSX.Element => {
         </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filteredSkills.map((skill) => (
-            <Card key={skill.id} className="bg-base-100/80">
+            <Card key={skill.id} className="border-white/20 bg-white/45">
               <h3 className="text-lg font-semibold text-base-content">{skill.name}</h3>
               <p className="mt-2 text-sm text-base-content/70">{skill.description}</p>
               <span className="mt-4 inline-flex w-fit rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
@@ -116,7 +119,7 @@ const ExplorePage = (): JSX.Element => {
             </Card>
           ))}
           {!filteredSkills.length && (
-            <Card className="bg-base-100/80 text-base-content/60">Prueba con otra palabra clave.</Card>
+            <Card className="text-base-content/60">Prueba con otra palabra clave.</Card>
           )}
         </div>
       </div>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -18,54 +18,51 @@ const quickStats = [
     id: 'impact',
     value: '48+',
     label: 'Lanzamientos significativos',
-    description: 'Productos desplegados en producción, desde plataformas SaaS hasta experiencias inmersivas.'
+    description: 'Productos end-to-end desplegados con métricas claras de adopción.'
   },
   {
     id: 'growth',
     value: '5x',
     label: 'Crecimiento de conversión',
-    description: 'Incremento promedio tras rediseñar flujos críticos con métricas de funnel en mente.'
+    description: 'Promedio tras rediseñar journeys críticos y medir iteraciones.'
   },
   {
     id: 'teams',
     value: '12',
     label: 'Equipos potenciados',
-    description: 'Liderando squads multidisciplinarios con metodologías de diseño colaborativo.'
+    description: 'Squads guiados con ceremonias de diseño y discovery continuo.'
   },
   {
     id: 'timeline',
     value: '10 años',
     label: 'Construyendo experiencias',
-    description: 'Especializado en diseñar productos escalables y encantadores para empresas en crecimiento.'
+    description: 'Diseño escalable con foco en accesibilidad, performance y emoción.'
   }
 ] as const;
 
-const designPillars = [
-  'Narrativas interactivas multidispositivo',
-  'Sistemas de diseño escalables con métricas',
-  'Animaciones con propósito y accesibilidad'
+const heroHighlights = [
+  'Diseño de productos SaaS y experiencias inmersivas',
+  'Sistemas de diseño componibles con documentación viva',
+  'Workshops, research y analítica para iterar con intención'
 ] as const;
 
 const processTimeline = [
   {
     id: '01',
     title: 'Descubrimiento inmersivo',
-    description:
-      'Workshops, shadowing y mapas de experiencia para detectar fricciones y oportunidades de alto impacto.',
+    description: 'Co-creación con stakeholders, mapeo de journeys y priorización de valor.',
     outcome: 'Insight accionable'
   },
   {
     id: '02',
     title: 'Prototipado sensorial',
-    description:
-      'Flujos interactivos de alta fidelidad, micro-interacciones y pruebas moderadas para validar emociones y utilidad.',
+    description: 'Prototipos de alta fidelidad, pruebas con usuarios y experimentos medibles.',
     outcome: 'Aprendizaje validado'
   },
   {
     id: '03',
     title: 'Delivery orquestado',
-    description:
-      'Documentación viva, sistemas de diseño componibles y métricas conectadas a observabilidad para un lanzamiento impecable.',
+    description: 'Design systems robustos, handoff impecable y métricas conectadas.',
     outcome: 'Entrega consistente'
   }
 ] as const;
@@ -91,81 +88,102 @@ const HomePage = (): JSX.Element => {
   const topSkills = useMemo(() => skills.slice(0, 6), [skills]);
 
   return (
-    <div className="relative space-y-24 pb-20">
-      <div className="pointer-events-none absolute inset-x-0 -top-24 -z-10 mx-auto h-[420px] max-w-5xl rounded-full bg-gradient-to-br from-primary/20 via-transparent to-secondary/20 blur-3xl" />
-
-      <section className="grid gap-10 pt-6 lg:grid-cols-[1.45fr,1fr] lg:items-center">
-        <Reveal className="space-y-8">
-          <span className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-sm font-medium tracking-wide text-primary">
-            {role} · Disponible para nuevos retos
-          </span>
-          <div className="space-y-4">
-            <h1 className="text-4xl font-bold leading-tight text-base-content md:text-5xl lg:text-6xl">{heroTitle}</h1>
-            <p className="text-lg text-base-content/70 md:text-xl">{heroSubtitle}</p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Link to={ctaPrimary.href} className={buttonStyles('primary', 'lg')}>
-              {ctaPrimary.label}
-            </Link>
-            <Link to={ctaSecondary.href} className={buttonStyles('secondary', 'lg')}>
-              {ctaSecondary.label}
-            </Link>
-          </div>
-          <ul className="grid gap-4 sm:grid-cols-3">
-            {designPillars.map((pillar) => (
-              <li key={pillar} className="group relative overflow-hidden rounded-2xl border border-base-200/60 bg-base-100/80 p-4 shadow-sm">
-                <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/15 via-transparent to-secondary/20 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-                <p className="text-sm font-medium text-base-content/80">{pillar}</p>
-              </li>
-            ))}
-          </ul>
-        </Reveal>
-        <Float duration={7000} amplitude={16} className="mx-auto w-full max-w-md">
-          <div className="relative overflow-hidden rounded-[2.75rem] border border-base-200/70 bg-base-100/95 p-8 shadow-xl shadow-primary/10">
-            <div className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-gradient-to-br from-primary/30 to-secondary/40 blur-2xl" aria-hidden="true" />
-            <div className="absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-gradient-to-br from-secondary/30 to-primary/20 blur-2xl" aria-hidden="true" />
-            <div className="relative space-y-4">
-              <p className="inline-flex items-center rounded-full bg-base-100/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
-                Experiencias inmersivas
-              </p>
-              <h2 className="text-2xl font-semibold text-base-content">Diseño centrado en micro-interacciones</h2>
-              <p className="text-base-content/70">
-                Arquitectura escalable, accesibilidad pragmática y animaciones con intención. Cada detalle del journey está diseñado para activar emoción y claridad desde el primer scroll.
-              </p>
-              <ul className="space-y-3 text-sm text-base-content/70">
-                <li className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-primary" /> Sistemas de diseño componibles y documentados
-                </li>
-                <li className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-secondary" /> Performance, métricas y observabilidad integradas
-                </li>
-                <li className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-accent" /> Animaciones fluidas con foco en UX y accesibilidad
-                </li>
-              </ul>
+    <div className="relative space-y-24 pb-24">
+      <section className="relative overflow-hidden rounded-[3rem] border border-white/20 bg-white/40 px-6 py-12 text-base-content shadow-glow backdrop-blur-xl transition-colors sm:px-10 md:px-14 dark:border-white/10 dark:bg-white/10">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-80" aria-hidden="true" />
+        <div className="pointer-events-none absolute -top-32 left-20 hidden h-64 w-64 rounded-full bg-primary/30 blur-3xl mix-blend-screen lg:block" aria-hidden="true" />
+        <div className="grid gap-12 lg:grid-cols-[1.35fr,1fr] lg:items-center">
+          <Reveal className="space-y-7">
+            <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium uppercase tracking-[0.3em] text-primary shadow-glow">
+              {role} · Disponible
+            </span>
+            <div className="space-y-4">
+              <h1 className="max-w-3xl text-4xl font-semibold leading-tight md:text-5xl lg:text-[3.6rem]">
+                <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
+                  {heroTitle}
+                </span>
+              </h1>
+              <p className="max-w-2xl text-lg text-base-content/70 md:text-xl">{heroSubtitle}</p>
             </div>
+            <div className="flex flex-wrap gap-3">
+              <Link to={ctaPrimary.href} className={buttonStyles('primary', 'lg')}>
+                {ctaPrimary.label}
+              </Link>
+              <Link to={ctaSecondary.href} className={buttonStyles('ghost', 'lg')}>
+                {ctaSecondary.label}
+              </Link>
+            </div>
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {heroHighlights.map((highlight) => (
+                <li
+                  key={highlight}
+                  className="group flex items-center gap-3 rounded-2xl border border-white/30 bg-white/50 px-4 py-3 text-sm text-base-content/80 transition hover:border-primary/50 hover:bg-primary/10 dark:border-white/10 dark:bg-white/5"
+                >
+                  <span className="grid h-8 w-8 place-items-center rounded-full bg-gradient-to-br from-primary/70 to-secondary/70 text-xs font-semibold text-primary-foreground shadow-glow">
+                    ★
+                  </span>
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+          </Reveal>
+
+          <div className="relative">
+            <Float duration={8000} amplitude={18} className="mx-auto max-w-sm">
+              <div className="relative overflow-hidden rounded-[2.5rem] border border-white/20 bg-gradient-to-br from-midnight/80 via-midnightMuted/80 to-midnight/90 p-8 text-white shadow-2xl backdrop-blur">
+                <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(34,211,238,0.35),transparent_65%)]" aria-hidden="true" />
+                <div className="space-y-6">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs uppercase tracking-[0.35em] text-secondary/80">Playbook</p>
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/20 px-3 py-1 text-xs text-white/70">
+                      Tiempo real
+                    </span>
+                  </div>
+                  <p className="text-2xl font-semibold text-white">Experiencias orquestadas</p>
+                  <p className="text-white/70">
+                    Mezclo visuales, research y código para acelerar lanzamientos. Cada entrega conecta decisiones con métricas tangibles.
+                  </p>
+                  <div className="grid gap-3 text-sm text-white/70">
+                    {quickStats.slice(0, 3).map((stat) => (
+                      <div key={stat.id} className="flex items-center justify-between rounded-2xl border border-white/20 bg-white/5 px-4 py-3">
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.3em] text-secondary/80">{stat.label}</p>
+                          <p className="text-sm text-white/80">{stat.description}</p>
+                        </div>
+                        <span className="text-xl font-semibold text-secondary">{stat.value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Float>
           </div>
-        </Float>
+        </div>
       </section>
 
       <section className="space-y-10">
-        <Reveal className="space-y-4">
-          <h2 className="text-3xl font-semibold text-base-content">Impacto medible en cada entrega</h2>
-          <p className="max-w-2xl text-base text-base-content/70">
-            Cada iniciativa se planifica con métricas de negocio y experiencia. Estos son algunos de los resultados recurrentes al diseñar productos centrados en las personas.
-          </p>
+        <Reveal className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-3xl font-semibold text-base-content">Impacto medible en cada entrega</h2>
+            <p className="max-w-2xl text-base text-base-content/70">
+              Experimentos, analítica y comunicación transparente para que cada release impulse el negocio y la experiencia.
+            </p>
+          </div>
+          <Link to="/projects" className={buttonStyles('outline', 'sm')}>
+            Ver portafolio completo
+          </Link>
         </Reveal>
         <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
           {quickStats.map((stat, index) => (
             <Reveal key={stat.id} delay={index * 80}>
               <ScaleOnHover className="h-full">
-                <Card className="flex h-full flex-col justify-between bg-base-100/80 p-6 backdrop-blur">
-                  <div className="space-y-4">
-                    <span className="text-4xl font-semibold text-base-content">{stat.value}</span>
+                <Card className="group flex h-full flex-col justify-between border-white/30 bg-white/50 p-6 text-base-content shadow-lg backdrop-blur dark:border-white/10 dark:bg-white/5">
+                  <div className="space-y-3">
+                    <span className="text-4xl font-semibold text-primary">{stat.value}</span>
                     <h3 className="text-lg font-semibold text-base-content/90">{stat.label}</h3>
                     <p className="text-sm text-base-content/70">{stat.description}</p>
                   </div>
-                  <div className="mt-6 h-1 rounded-full bg-gradient-to-r from-primary/70 via-secondary/70 to-accent/70" />
+                  <div className="mt-6 h-1 rounded-full bg-gradient-to-r from-primary via-secondary to-accent" />
                 </Card>
               </ScaleOnHover>
             </Reveal>
@@ -174,11 +192,13 @@ const HomePage = (): JSX.Element => {
       </section>
 
       <section className="space-y-8">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Proyectos recientes</h2></Reveal>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Proyectos recientes</h2>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/projects" className={buttonStyles('ghost', 'sm')}>
-              Ver todos
+              Explorar proyectos
             </Link>
           </Reveal>
         </div>
@@ -192,8 +212,10 @@ const HomePage = (): JSX.Element => {
       </section>
 
       <section className="space-y-8">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Experiencia destacada</h2></Reveal>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Experiencia destacada</h2>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/about" className={buttonStyles('ghost', 'sm')}>
               Ver trayectoria completa
@@ -201,12 +223,12 @@ const HomePage = (): JSX.Element => {
           </Reveal>
         </div>
         <div className="relative">
-          <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-base-100 to-transparent" aria-hidden="true" />
-          <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-base-100 to-transparent" aria-hidden="true" />
+          <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-midnight/70 to-transparent dark:from-midnight" aria-hidden="true" />
+          <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-midnight/70 to-transparent dark:from-midnight" aria-hidden="true" />
           <div className="flex snap-x gap-6 overflow-x-auto pb-6 pr-6 sm:pr-0">
             {experienceTimeline.map((item, index) => (
               <Reveal key={item.id} delay={index * 80} className="min-w-[280px] snap-center">
-                <Card className="h-full bg-base-100/80 p-6">
+                <Card className="h-full border-white/30 bg-white/50 p-6 text-base-content transition-colors dark:border-white/10 dark:bg-white/5">
                   <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/80">{item.period}</p>
                   <h3 className="mt-4 text-lg font-semibold text-base-content">{item.title}</h3>
                   <p className="mt-3 text-sm text-base-content/70">{item.description}</p>
@@ -218,11 +240,13 @@ const HomePage = (): JSX.Element => {
       </section>
 
       <section className="space-y-8">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Últimas publicaciones</h2></Reveal>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Últimas publicaciones</h2>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/posts" className={buttonStyles('ghost', 'sm')}>
-              Leer más
+              Leer más ideas
             </Link>
           </Reveal>
         </div>
@@ -239,16 +263,16 @@ const HomePage = (): JSX.Element => {
         <Reveal className="space-y-3">
           <h2 className="text-3xl font-semibold text-base-content">Un proceso pensado para sorprender</h2>
           <p className="max-w-2xl text-base text-base-content/70">
-            Desde el primer contacto hasta el lanzamiento, diseño experiencias memorables y coherentes. Así conecto estrategia, diseño y ejecución.
+            El journey completo, desde el primer workshop hasta el monitoreo en producción, diseñado para generar adopción sostenida y experiencias memorables.
           </p>
         </Reveal>
         <div className="grid gap-6 md:grid-cols-3">
           {processTimeline.map((step, index) => (
             <Reveal key={step.id} delay={index * 120}>
               <ScaleOnHover className="h-full">
-                <Card className="flex h-full flex-col justify-between bg-base-100/85 p-6">
+                <Card className="flex h-full flex-col justify-between border-white/30 bg-white/55 p-6 text-base-content backdrop-blur dark:border-white/10 dark:bg-white/5">
                   <div className="space-y-4">
-                    <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                    <span className="inline-flex items-center gap-2 rounded-full bg-primary/15 px-3 py-1 text-xs font-semibold text-primary">
                       Fase {step.id}
                     </span>
                     <h3 className="text-lg font-semibold text-base-content">{step.title}</h3>
@@ -266,8 +290,10 @@ const HomePage = (): JSX.Element => {
       </section>
 
       <section className="space-y-8">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Stack principal</h2></Reveal>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Stack principal</h2>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/skills" className={buttonStyles('ghost', 'sm')}>
               Ver todas las skills
@@ -283,12 +309,14 @@ const HomePage = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="relative overflow-hidden rounded-3xl border border-primary/10 bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 p-10 text-base-content shadow-xl">
-        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.25),transparent_60%)]" aria-hidden="true" />
+      <section className="relative overflow-hidden rounded-[3rem] border border-primary/30 bg-gradient-to-br from-primary/15 via-white/50 to-secondary/15 p-12 text-base-content shadow-glow backdrop-blur-xl dark:border-primary/20 dark:from-primary/20 dark:via-midnightMuted/80 dark:to-secondary/20">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(124,58,237,0.3),transparent_55%)]" aria-hidden="true" />
         <Reveal className="space-y-6">
-          <h2 className="text-3xl font-semibold md:text-4xl">¿Listo para elevar la siguiente experiencia digital?</h2>
+          <h2 className="text-3xl font-semibold md:text-4xl">
+            ¿Listo para elevar la siguiente experiencia digital?
+          </h2>
           <p className="max-w-3xl text-base-content/70 md:text-lg">
-            Conecto estrategia, diseño y código para lanzar productos memorables. Hablemos sobre cómo podemos construir algo extraordinario para tu audiencia.
+            Conecto estrategia, diseño y código para lanzar productos memorables. Hablemos de tu próximo reto y diseñemos juntos un roadmap irresistible.
           </p>
           <div className="flex flex-wrap gap-3">
             <Link to="/contact" className={buttonStyles('primary', 'lg')}>

--- a/src/pages/NotFound/NotFoundPage.tsx
+++ b/src/pages/NotFound/NotFoundPage.tsx
@@ -5,7 +5,7 @@ import { Reveal } from 'react-bits';
 
 const NotFoundPage = (): JSX.Element => {
   return (
-    <Reveal className="flex flex-col items-center gap-6 py-20 text-center">
+    <Reveal className="mx-auto flex max-w-3xl flex-col items-center gap-6 rounded-[2.5rem] border border-white/20 bg-white/40 px-8 py-16 text-center text-base-content shadow-glow backdrop-blur-xl dark:border-white/10 dark:bg-white/10">
       <span className="text-7xl">🪐</span>
       <h1 className="text-4xl font-bold text-base-content">Esta página se perdió en el cosmos</h1>
       <p className="max-w-lg text-base-content/70">

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -6,11 +6,12 @@ const baseStyles =
   'inline-flex items-center justify-center gap-2 rounded-xl border font-medium transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-60';
 
 const variants = {
-  primary: 'border-primary bg-primary text-primary-foreground shadow-lg shadow-primary/20 hover:-translate-y-0.5 hover:shadow-xl',
+  primary:
+    'border-primary bg-gradient-to-r from-primary via-aurora to-secondary text-primary-foreground shadow-lg shadow-primary/30 hover:-translate-y-0.5 hover:shadow-xl',
   secondary:
-    'border-transparent bg-base-200 text-base-content hover:-translate-y-0.5 hover:bg-base-300 hover:shadow-md',
+    'border-white/30 bg-white/60 text-base-content shadow-md hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/10 dark:border-white/10 dark:bg-white/10',
   outline:
-    'border-base-300 bg-transparent text-base-content hover:border-primary hover:text-primary',
+    'border-white/40 bg-transparent text-base-content hover:border-primary hover:text-primary dark:border-white/20',
   ghost: 'border-transparent bg-transparent text-base-content/80 hover:text-primary hover:bg-primary/10'
 } as const;
 

--- a/src/shared/components/Card.tsx
+++ b/src/shared/components/Card.tsx
@@ -26,15 +26,15 @@ const Card = ({
   return (
     <Component
       className={cn(
-        'group relative overflow-hidden rounded-2xl border border-base-200 bg-base-100 shadow-sm transition-all duration-300',
+        'group relative overflow-hidden rounded-2xl border border-white/25 bg-white/40 text-base-content shadow-md backdrop-blur transition-all duration-300 dark:border-white/10 dark:bg-white/5',
         hoverable &&
-          'hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/40',
+          'hover:-translate-y-1 hover:border-primary/40 hover:shadow-xl hover:shadow-primary/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/40',
         paddingMap[padding],
         className
       )}
     >
       <div className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-300 group-hover:opacity-100" aria-hidden="true">
-        <div className="h-full w-full bg-gradient-to-br from-primary/10 via-transparent to-accent/10" />
+        <div className="h-full w-full bg-gradient-to-br from-primary/15 via-transparent to-secondary/20" />
       </div>
       {children}
     </Component>

--- a/src/shared/components/Loader.tsx
+++ b/src/shared/components/Loader.tsx
@@ -6,9 +6,9 @@ interface LoaderProps {
 
 const Loader = ({ message = 'Cargando...', fullScreen = false, overlay = false }: LoaderProps): JSX.Element => {
   const containerClasses = fullScreen
-    ? 'fixed inset-0 z-40 flex items-center justify-center bg-base-100/80 backdrop-blur'
+    ? 'fixed inset-0 z-40 flex items-center justify-center bg-white/60 backdrop-blur dark:bg-midnightMuted/80'
     : overlay
-      ? 'absolute inset-0 z-30 flex items-center justify-center rounded-2xl bg-base-100/80 backdrop-blur'
+      ? 'absolute inset-0 z-30 flex items-center justify-center rounded-2xl bg-white/60 backdrop-blur dark:bg-midnightMuted/80'
       : 'flex w-full items-center justify-center py-10';
 
   return (

--- a/src/shared/components/MarkdownRenderer.tsx
+++ b/src/shared/components/MarkdownRenderer.tsx
@@ -9,7 +9,11 @@ interface MarkdownRendererProps {
 const MarkdownRenderer = ({ content }: MarkdownRendererProps): JSX.Element => {
   const blocks: ReactNode[] = renderMarkdownBlocks(content);
 
-  return <div className="prose prose-neutral max-w-none dark:prose-invert">{blocks}</div>;
+  return (
+    <div className="prose prose-neutral max-w-none text-base-content/80 prose-headings:text-base-content prose-a:text-primary hover:prose-a:text-aurora dark:prose-invert">
+      {blocks}
+    </div>
+  );
 };
 
 export default MarkdownRenderer;

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-type Theme = 'light' | 'dark';
+type Theme = 'lumen' | 'dark';
 
 interface ThemeState {
   theme: Theme;
@@ -12,12 +12,12 @@ interface ThemeState {
 const STORAGE_KEY = 'portfolio_theme';
 
 export const useThemeStore = create<ThemeState>((set, get) => ({
-  theme: 'light',
+  theme: 'lumen',
   initializeTheme: () => {
     if (typeof window === 'undefined') return;
     const storedTheme = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
     const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
-    const nextTheme = storedTheme ?? (prefersDark ? 'dark' : 'light');
+    const nextTheme = storedTheme ?? (prefersDark ? 'dark' : 'lumen');
     if (nextTheme !== get().theme) {
       set({ theme: nextTheme });
     }
@@ -30,7 +30,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   },
   toggleTheme: () => {
     const current = get().theme;
-    const nextTheme: Theme = current === 'light' ? 'dark' : 'light';
+    const nextTheme: Theme = current === 'lumen' ? 'dark' : 'lumen';
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(STORAGE_KEY, nextTheme);
     }

--- a/src/widgets/Footer.tsx
+++ b/src/widgets/Footer.tsx
@@ -2,30 +2,68 @@ import { Link } from 'react-router-dom';
 
 import { navItems } from './navItems';
 
+const socialLinks = [
+  { label: 'LinkedIn', href: 'https://linkedin.com', caption: 'Actualizaciones profesionales' },
+  { label: 'Dribbble', href: 'https://dribbble.com', caption: 'Experimentos visuales' },
+  { label: 'Github', href: 'https://github.com', caption: 'Código abierto y librerías' }
+];
+
 const Footer = (): JSX.Element => {
   return (
-    <footer className="border-t border-base-200 bg-base-100/80">
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-base-content/70 md:flex-row md:items-center md:justify-between md:px-8">
-        <div>
-          <p className="font-semibold text-base-content">Laura Méndez · Frontend Engineer</p>
-          <p className="mt-2 max-w-md">
-            Construyendo productos digitales que combinan narrativa visual, ingeniería sólida y experiencias accesibles.
-          </p>
-        </div>
-        <nav className="flex flex-wrap gap-3 text-base-content/70">
-          {navItems.map((item) => (
-            <Link key={item.to} to={item.to} className="hover:text-primary">
-              {item.label}
+    <footer className="relative mt-12 overflow-hidden rounded-t-[2.5rem] border-t border-white/10 bg-white/30 text-base-content backdrop-blur-xl dark:border-white/5 dark:bg-white/5">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-80" aria-hidden="true" />
+      <div className="mx-auto max-w-6xl px-4 py-16 md:px-8">
+        <div className="grid gap-10 md:grid-cols-[1.2fr,0.9fr,1fr]">
+          <div className="space-y-4">
+            <Link to="/" className="inline-flex items-center gap-3 text-lg font-semibold">
+              <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-aurora to-secondary text-primary-foreground shadow-glow">
+                LM
+              </span>
+              <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
+                Laura Méndez
+              </span>
             </Link>
-          ))}
-        </nav>
-        <div className="space-y-1 text-right md:text-left">
-          <p>Disponible para colaboraciones selectas.</p>
-          <p className="font-medium text-base-content">hola@lauramendez.dev</p>
+            <p className="text-base text-base-content/80">
+              Estrategia, diseño y código integrados para lanzar productos memorables. Creo experiencias que construyen confianza y crecimiento sostenido.
+            </p>
+            <Link
+              to="/contact"
+              className="inline-flex items-center gap-2 rounded-2xl border border-primary/40 bg-primary/10 px-5 py-3 text-sm font-semibold text-primary shadow-glow hover:bg-primary/15"
+            >
+              Reserva una consultoría express →
+            </Link>
+          </div>
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-base-content/60">Explorar</p>
+            <nav className="mt-4 grid grid-cols-2 gap-3 text-sm">
+              {navItems.map((item) => (
+                <Link key={item.to} to={item.to} className="rounded-xl bg-white/40 px-4 py-3 text-base-content/80 transition hover:bg-primary/10 hover:text-primary dark:bg-white/10">
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-base-content/60">Conecta</p>
+            <ul className="mt-4 space-y-3 text-sm">
+              {socialLinks.map((item) => (
+                <li key={item.label} className="group rounded-2xl border border-white/20 bg-white/40 p-4 transition hover:border-primary/40 hover:bg-primary/10 dark:border-white/10 dark:bg-white/5">
+                  <a href={item.href} target="_blank" rel="noreferrer" className="flex flex-col gap-1">
+                    <span className="flex items-center justify-between text-base font-medium text-base-content">
+                      {item.label}
+                      <span aria-hidden="true" className="text-primary transition group-hover:translate-x-1">→</span>
+                    </span>
+                    <span className="text-xs text-base-content/60">{item.caption}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
-      </div>
-      <div className="border-t border-base-200/80 bg-base-200/50 py-4 text-center text-xs text-base-content/60">
-        © {new Date().getFullYear()} Laura Méndez. Diseñado con cariño y código.
+        <div className="mt-10 flex flex-col gap-3 border-t border-white/10 pt-6 text-xs text-base-content/60 md:flex-row md:items-center md:justify-between">
+          <p>Disponible para colaboraciones selectas · hola@lauramendez.dev</p>
+          <p>© {new Date().getFullYear()} Laura Méndez · Crafted with intención y tecnología.</p>
+        </div>
       </div>
     </footer>
   );

--- a/src/widgets/Navbar.tsx
+++ b/src/widgets/Navbar.tsx
@@ -12,48 +12,62 @@ const Navbar = (): JSX.Element => {
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-base-200/80 bg-base-100/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 md:px-8">
-        <Link to="/" className="flex items-center gap-2 text-lg font-semibold">
-          <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-lg shadow-primary/30">
-            LM
-          </span>
-          <span className="hidden sm:inline">Laura Méndez</span>
-        </Link>
-        <nav className="hidden items-center gap-1 rounded-2xl border border-base-200 bg-base-100/80 px-2 py-1 shadow-sm md:flex">
-          {navItems.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              className={({ isActive }) =>
-                cn(
-                  'rounded-xl px-3 py-2 text-sm font-medium text-base-content/70 transition hover:bg-base-200',
-                  isActive && 'bg-base-200 text-base-content'
-                )
-              }
-              end={item.to === '/'}
+    <header className="fixed inset-x-0 top-0 z-40 flex justify-center bg-transparent">
+      <div className="relative mx-auto mt-4 w-[94%] max-w-6xl overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-3 shadow-glow backdrop-blur-xl transition md:w-[92%] dark:border-white/5 dark:bg-white/5">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-glow opacity-70 blur-30" aria-hidden="true" />
+        <div className="flex items-center justify-between gap-4">
+          <Link to="/" className="group flex items-center gap-2 text-lg font-semibold text-base-content">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-aurora to-secondary text-sm font-bold text-primary-foreground shadow-glow">
+              LM
+            </span>
+            <span className="hidden bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent sm:inline">
+              Laura Méndez
+            </span>
+          </Link>
+          <nav className="hidden items-center gap-1 rounded-2xl border border-white/20 bg-white/40 px-2 py-1 text-sm shadow-sm dark:border-white/10 dark:bg-white/10 md:flex">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  cn(
+                    'relative rounded-xl px-4 py-2 font-medium text-base-content/80 transition focus-visible:outline-none hover:text-primary',
+                    isActive &&
+                      'text-primary'
+                  )
+                }
+                end={item.to === '/'}
+              >
+                {({ isActive }) => (
+                  <span className="relative flex items-center gap-2">
+                    {isActive && <span className="h-2 w-2 rounded-full bg-primary shadow-glow" aria-hidden="true" />}
+                    {item.label}
+                  </span>
+                )}
+              </NavLink>
+            ))}
+          </nav>
+          <div className="flex items-center gap-3">
+            <div className="hidden w-48 lg:block">
+              <SearchBar />
+            </div>
+            <ThemeToggle />
+            <Link to="/contact" className="hidden rounded-xl border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium text-primary shadow-glow hover:bg-primary/15 sm:inline-flex">
+              Hablemos
+            </Link>
+            <button
+              type="button"
+              className={cn(buttonStyles('ghost', 'sm'), 'md:hidden border border-white/20 bg-white/40 dark:bg-white/10')}
+              onClick={toggleSidebar}
+              aria-label="Abrir menú"
             >
-              {item.label}
-            </NavLink>
-          ))}
-        </nav>
-        <div className="flex items-center gap-3">
-          <div className="hidden lg:block">
-            <SearchBar />
+              ☰
+            </button>
           </div>
-          <ThemeToggle />
-          <button
-            type="button"
-            className={cn(buttonStyles('ghost', 'sm'), 'md:hidden')}
-            onClick={toggleSidebar}
-            aria-label="Abrir menú"
-          >
-            ☰
-          </button>
         </div>
-      </div>
-      <div className="px-4 pb-4 md:hidden">
-        <SearchBar />
+        <div className="mt-3 block md:hidden">
+          <SearchBar />
+        </div>
       </div>
     </header>
   );

--- a/src/widgets/SearchBar.tsx
+++ b/src/widgets/SearchBar.tsx
@@ -20,13 +20,13 @@ const SearchBar = (): JSX.Element => {
         value={query}
         onChange={handleChange}
         placeholder="Buscar proyectos, artículos o skills"
-        className="w-full rounded-2xl border border-base-300 bg-base-100 py-3 pl-11 pr-12 text-sm shadow-sm transition focus:border-primary focus:outline-none"
+        className="w-full rounded-2xl border border-white/30 bg-white/60 py-3 pl-11 pr-12 text-sm text-base-content shadow-inner transition focus:border-primary focus:outline-none dark:border-white/10 dark:bg-white/10"
       />
       {query && (
         <button
           type="button"
           onClick={clearSearch}
-          className="absolute right-3 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-base-200 text-xs text-base-content/60 hover:bg-base-300"
+          className="absolute right-3 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-white/30 bg-white/60 text-xs text-base-content/60 transition hover:bg-primary/10 hover:text-primary dark:border-white/10 dark:bg-white/10"
           aria-label="Limpiar búsqueda"
         >
           ×

--- a/src/widgets/Sidebar.tsx
+++ b/src/widgets/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 
 import { cn } from '@shared/utils/cn';
 import { useUIStore } from '@stores/uiStore';
@@ -16,21 +16,22 @@ const Sidebar = (): JSX.Element => {
   return (
     <aside
       className={cn(
-        'fixed inset-y-0 left-0 z-50 w-72 transform border-r border-base-200 bg-base-100/95 p-6 shadow-xl backdrop-blur transition-transform duration-300 md:hidden',
+        'fixed inset-y-0 left-0 z-50 w-72 transform bg-white/80 p-6 text-base-content shadow-2xl shadow-primary/20 backdrop-blur-xl transition-transform duration-300 md:hidden dark:bg-midnightMuted/80',
         isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
       )}
     >
       <div className="flex items-center justify-between">
-        <span className="text-lg font-semibold">Navegación</span>
+        <span className="text-lg font-semibold">Menú</span>
         <button
           type="button"
-          className="rounded-full bg-base-200 px-3 py-1 text-sm"
+          className="rounded-full border border-white/30 bg-white/40 px-3 py-1 text-sm font-medium shadow-sm hover:bg-white/70 dark:border-white/10 dark:bg-white/10"
           onClick={toggleSidebar}
           aria-label="Cerrar menú"
         >
           Cerrar
         </button>
       </div>
+      <p className="mt-2 text-sm text-base-content/60">Explora cada capa del portafolio.</p>
       <nav className="mt-6 flex flex-col gap-2">
         {navItems.map((item) => (
           <NavLink
@@ -40,8 +41,8 @@ const Sidebar = (): JSX.Element => {
             end={item.to === '/'}
             className={({ isActive }) =>
               cn(
-                'rounded-xl px-4 py-3 text-base font-medium text-base-content/70 transition hover:bg-base-200',
-                isActive && 'bg-base-200 text-base-content'
+                'rounded-2xl px-4 py-3 text-base font-medium text-base-content/75 transition hover:bg-primary/10 hover:text-primary',
+                isActive && 'bg-primary/15 text-primary shadow-glow'
               )
             }
           >
@@ -49,7 +50,18 @@ const Sidebar = (): JSX.Element => {
           </NavLink>
         ))}
       </nav>
-      <div className="mt-10">
+      <div className="mt-10 space-y-3">
+        <div className="rounded-2xl border border-white/20 bg-white/40 p-4 text-sm shadow-sm dark:border-white/10 dark:bg-white/5">
+          <p className="font-semibold text-base-content">¿Tienes un reto?</p>
+          <p className="mt-1 text-base-content/70">Agenda una llamada estratégica y diseñemos la solución.</p>
+          <Link
+            to="/contact"
+            onClick={closeSidebar}
+            className="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:text-aurora"
+          >
+            Ir a contacto →
+          </Link>
+        </div>
         <ThemeToggle />
       </div>
     </aside>

--- a/src/widgets/ThemeToggle.tsx
+++ b/src/widgets/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { buttonStyles } from '@shared/components/Button';
 const ThemeToggle = (): JSX.Element => {
   const { theme, toggleTheme } = useTheme();
   const isDark = theme === 'dark';
+  const label = isDark ? 'Modo oscuro' : 'Modo aurora';
 
   return (
     <button
@@ -13,7 +14,7 @@ const ThemeToggle = (): JSX.Element => {
       onClick={toggleTheme}
     >
       {isDark ? '🌙' : '☀️'}
-      <span className="ml-2 hidden text-sm sm:inline">{isDark ? 'Modo oscuro' : 'Modo claro'}</span>
+      <span className="ml-2 hidden text-sm sm:inline">{label}</span>
     </button>
   );
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,20 +12,94 @@ const config: Config = {
       },
       colors: {
         primary: {
-          DEFAULT: '#6366f1',
-          foreground: '#ffffff'
+          DEFAULT: '#7c3aed',
+          foreground: '#f4f3ff'
+        },
+        secondary: {
+          DEFAULT: '#22d3ee',
+          foreground: '#001524'
         },
         accent: {
           DEFAULT: '#f97316',
           foreground: '#0f172a'
+        },
+        midnight: '#050b1a',
+        midnightMuted: '#0b1220',
+        aurora: '#a855f7'
+      },
+      backgroundImage: {
+        'hero-glow':
+          'radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.55), transparent 55%), radial-gradient(circle at 80% 10%, rgba(34, 211, 238, 0.45), transparent 50%), radial-gradient(circle at 50% 100%, rgba(249, 115, 22, 0.35), transparent 55%)',
+        'mesh-gradient':
+          'linear-gradient(135deg, rgba(15, 23, 42, 0.9) 0%, rgba(5, 11, 26, 0.88) 45%, rgba(8, 47, 73, 0.92) 100%)',
+        'grid-slate': 'linear-gradient(to right, rgba(148, 163, 184, 0.07) 1px, transparent 1px), linear-gradient(to bottom, rgba(148, 163, 184, 0.07) 1px, transparent 1px)'
+      },
+      boxShadow: {
+        glow: '0 0 45px -15px rgba(124, 58, 237, 0.55)',
+        'glow-secondary': '0 0 55px -20px rgba(34, 211, 238, 0.6)',
+        'glow-accent': '0 0 55px -18px rgba(249, 115, 22, 0.65)'
+      },
+      keyframes: {
+        aurora: {
+          '0%': {
+            transform: 'rotate(0deg) scale(1)',
+            opacity: '0.4'
+          },
+          '50%': {
+            transform: 'rotate(8deg) scale(1.05)',
+            opacity: '0.7'
+          },
+          '100%': {
+            transform: 'rotate(0deg) scale(1)',
+            opacity: '0.4'
+          }
+        },
+        float: {
+          '0%, 100%': { transform: 'translateY(0px)' },
+          '50%': { transform: 'translateY(-12px)' }
+        },
+        shimmer: {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(100%)' }
         }
+      },
+      animation: {
+        aurora: 'aurora 18s ease-in-out infinite',
+        float: 'float 8s ease-in-out infinite',
+        shimmer: 'shimmer 12s linear infinite'
+      },
+      blur: {
+        30: '30px'
       }
     }
   },
   plugins: [daisyui],
   daisyui: {
     darkTheme: 'dark',
-    themes: ['light', 'dark']
+    themes: [
+      {
+        lumen:
+          {
+            primary: '#7c3aed',
+            'primary-content': '#f4f3ff',
+            secondary: '#22d3ee',
+            'secondary-content': '#001524',
+            accent: '#f97316',
+            'accent-content': '#0f172a',
+            neutral: '#111827',
+            'neutral-content': '#f8fafc',
+            'base-100': '#f8fafc',
+            'base-200': '#e2e8f0',
+            'base-300': '#cbd5f5',
+            'base-content': '#0f172a',
+            info: '#38bdf8',
+            success: '#22c55e',
+            warning: '#facc15',
+            error: '#f87171'
+          }
+      },
+      'dark'
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- adopt an aurora-inspired Tailwind palette and mesh backgrounds to modernize the base theme
- redesign navigation shell, footer, and shared cards/buttons with glassmorphism accents and CTAs
- rebuild hero, showcase, and contact sections across key pages for a dynamic, market-ready presentation

## Testing
- ⚠️ `npm install --include=dev --no-progress` *(fails in container with repeated MaxListenersExceededWarning, preventing dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68d446a5f034832e9af2b2489aec51f3