### PR TITLE
feat: renovar diseño principal del portafolio

### DIFF
--- a/src/app/layouts/MainLayout.tsx
+++ b/src/app/layouts/MainLayout.tsx
@@ -20,11 +20,12 @@ const MainLayout = () => {
   const isNavigating = navigation.state === 'loading';
 
   return (
-    <div className="min-h-screen bg-base-100 text-base-content transition-colors">
+    <div className="relative min-h-screen bg-base-100 text-base-content transition-colors">
+      <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.12),transparent_55%)]" aria-hidden="true" />
       <ScrollProgressBar />
       <Navbar />
       <Sidebar />
-      <main className="relative mx-auto flex min-h-[70vh] max-w-6xl flex-1 flex-col px-4 pb-20 pt-24 md:px-8">
+      <main className="relative mx-auto flex min-h-[70vh] max-w-7xl flex-1 flex-col px-5 pb-24 pt-28 md:px-10">
         {isNavigating && <Loader overlay message="Actualizando sección..." />}
         <div className={isNavigating ? 'pointer-events-none opacity-50' : ''}>
           <Outlet />

--- a/src/index.css
+++ b/src/index.css
@@ -14,40 +14,63 @@ body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   min-height: 100vh;
   position: relative;
-  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(249, 115, 22, 0.12), transparent 60%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.02) 0%, rgba(255, 255, 255, 0) 40%);
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 60%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.02) 0%, rgba(255, 255, 255, 0) 45%);
 }
 
 body::before,
 body::after {
   content: '';
   position: fixed;
-  width: 520px;
-  height: 520px;
-  border-radius: 9999px;
-  filter: blur(140px);
-  opacity: 0.35;
   pointer-events: none;
   z-index: -1;
-  animation: aurora 18s ease-in-out infinite;
+  transition: opacity 0.3s ease;
 }
 
 body::before {
-  top: -160px;
+  top: -140px;
   left: -120px;
-  background: radial-gradient(circle at center, rgba(79, 70, 229, 0.4), transparent 65%);
+  width: 560px;
+  height: 560px;
+  border-radius: 9999px;
+  filter: blur(140px);
+  opacity: 0.35;
+  background: radial-gradient(circle at center, rgba(99, 102, 241, 0.5), transparent 65%);
+  animation: aurora 18s ease-in-out infinite;
 }
 
 body::after {
+  right: -120px;
   bottom: -160px;
-  right: -80px;
-  background: radial-gradient(circle at center, rgba(251, 191, 36, 0.45), transparent 60%);
+  width: 620px;
+  height: 620px;
+  border-radius: 9999px;
+  filter: blur(160px);
+  opacity: 0.32;
+  background: radial-gradient(circle at center, rgba(14, 165, 233, 0.45), transparent 62%);
+  animation: aurora 22s ease-in-out infinite;
   animation-delay: 6s;
 }
 
 a {
   @apply transition-colors duration-200;
+}
+
+main::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  max-width: 80rem;
+  height: 100%;
+  border-radius: 2.5rem;
+  opacity: 0.35;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.4), transparent 70%);
+  background-image: var(--grid-background, linear-gradient(90deg, rgba(99, 102, 241, 0.06) 1px, transparent 1px),
+      linear-gradient(180deg, rgba(99, 102, 241, 0.06) 1px, transparent 1px));
+  background-size: 140px 140px;
+  z-index: -1;
 }
 
 ::-webkit-scrollbar {
@@ -59,7 +82,7 @@ a {
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-primary/60 rounded-full;
+  @apply rounded-full bg-primary/60;
 }
 
 @keyframes aurora {
@@ -68,7 +91,7 @@ a {
     opacity: 0.28;
   }
   50% {
-    transform: translate3d(5%, -8%, 0) scale(1.05);
+    transform: translate3d(6%, -10%, 0) scale(1.08);
     opacity: 0.45;
   }
   100% {
@@ -78,15 +101,15 @@ a {
 }
 
 [data-theme='dark'] body {
-  background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.2), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(251, 191, 36, 0.18), transparent 60%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0) 45%);
+  background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(34, 211, 238, 0.2), transparent 60%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.1) 0%, rgba(15, 23, 42, 0) 45%);
 }
 
 [data-theme='dark'] body::before {
-  background: radial-gradient(circle at center, rgba(129, 140, 248, 0.55), transparent 65%);
+  background: radial-gradient(circle at center, rgba(129, 140, 248, 0.6), transparent 65%);
 }
 
 [data-theme='dark'] body::after {
-  background: radial-gradient(circle at center, rgba(251, 191, 36, 0.35), transparent 60%);
+  background: radial-gradient(circle at center, rgba(34, 211, 238, 0.5), transparent 60%);
 }

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -12,62 +12,130 @@ import ProjectCard from '@features/projects/components/ProjectCard';
 import PostCard from '@features/posts/components/PostCard';
 import SkillBadge from '@features/skills/components/SkillBadge';
 import { Float, Reveal, ScaleOnHover } from 'react-bits';
+import { cn } from '@shared/utils/cn';
+
+const heroHighlights = [
+  {
+    id: 'highlight-systems',
+    title: 'Sistemas vivos',
+    description: 'Design tokens, documentación viva y handoff impecable para lanzar sin fricción.'
+  },
+  {
+    id: 'highlight-growth',
+    title: 'Crecimiento medible',
+    description: 'Experimentos guiados por funnel, analítica en tiempo real y métricas accionables.'
+  },
+  {
+    id: 'highlight-experience',
+    title: 'Experiencias inmersivas',
+    description: 'Micro-interacciones con intención, accesibilidad pragmática y performance ágil.'
+  }
+] as const;
+
+const heroSignals = [
+  {
+    id: 'signal-impact',
+    label: 'Conversión promedio',
+    value: '5x',
+    badgeClass: 'bg-primary/15 text-primary',
+    glowClass: 'from-primary/40 via-primary/10 to-transparent'
+  },
+  {
+    id: 'signal-teams',
+    label: 'Equipos potenciados',
+    value: '12',
+    badgeClass: 'bg-secondary/20 text-secondary',
+    glowClass: 'from-secondary/50 via-secondary/10 to-transparent'
+  },
+  {
+    id: 'signal-deliveries',
+    label: 'Lanzamientos en producción',
+    value: '48+',
+    badgeClass: 'bg-accent/20 text-accent',
+    glowClass: 'from-accent/40 via-accent/10 to-transparent'
+  }
+] as const;
+
+const innovationTracks = [
+  {
+    id: 'track-journeys',
+    icon: '🌀',
+    title: 'Journeys adaptables',
+    detail: 'Mapas de experiencia que se actualizan con señal de negocio real.'
+  },
+  {
+    id: 'track-co',
+    icon: '🤝',
+    title: 'Co-creación estratégica',
+    detail: 'Workshops inmersivos con stakeholders para alinear visión y entregables.'
+  },
+  {
+    id: 'track-data',
+    icon: '📊',
+    title: 'Decisiones basadas en data',
+    detail: 'Dashboards conectados al journey para iterar con evidencia.'
+  },
+  {
+    id: 'track-motion',
+    icon: '✨',
+    title: 'Animación con propósito',
+    detail: 'Micro-interacciones accesibles que refuerzan claridad y emoción.'
+  }
+] as const;
 
 const quickStats = [
   {
     id: 'impact',
     value: '48+',
     label: 'Lanzamientos significativos',
-    description: 'Productos desplegados en producción, desde plataformas SaaS hasta experiencias inmersivas.'
+    description: 'SaaS, plataformas educativas y experiencias inmersivas en producción.'
   },
   {
     id: 'growth',
     value: '5x',
-    label: 'Crecimiento de conversión',
-    description: 'Incremento promedio tras rediseñar flujos críticos con métricas de funnel en mente.'
+    label: 'Aceleración promedio',
+    description: 'Incremento en conversión al rediseñar journeys críticos con foco en métricas.'
   },
   {
     id: 'teams',
     value: '12',
     label: 'Equipos potenciados',
-    description: 'Liderando squads multidisciplinarios con metodologías de diseño colaborativo.'
+    description: 'Squads multidisciplinarios con procesos y herramientas compartidas.'
   },
   {
     id: 'timeline',
     value: '10 años',
     label: 'Construyendo experiencias',
-    description: 'Especializado en diseñar productos escalables y encantadores para empresas en crecimiento.'
+    description: 'End-to-end product design con entregables listos para ingeniería.'
   }
-] as const;
-
-const designPillars = [
-  'Narrativas interactivas multidispositivo',
-  'Sistemas de diseño escalables con métricas',
-  'Animaciones con propósito y accesibilidad'
 ] as const;
 
 const processTimeline = [
   {
     id: '01',
     title: 'Descubrimiento inmersivo',
-    description:
-      'Workshops, shadowing y mapas de experiencia para detectar fricciones y oportunidades de alto impacto.',
+    description: 'Research mixto, sesiones de co-creación y análisis de datos para encontrar oportunidades claras.',
     outcome: 'Insight accionable'
   },
   {
     id: '02',
     title: 'Prototipado sensorial',
-    description:
-      'Flujos interactivos de alta fidelidad, micro-interacciones y pruebas moderadas para validar emociones y utilidad.',
+    description: 'Flows interactivos de alta fidelidad, pruebas iterativas y motion que guía la atención.',
     outcome: 'Aprendizaje validado'
   },
   {
     id: '03',
     title: 'Delivery orquestado',
-    description:
-      'Documentación viva, sistemas de diseño componibles y métricas conectadas a observabilidad para un lanzamiento impecable.',
+    description: 'Design system componible, documentación viva y medición continua para el lanzamiento.',
     outcome: 'Entrega consistente'
   }
+] as const;
+
+const accentGradients = [
+  'from-primary/60 via-primary/10 to-transparent',
+  'from-secondary/60 via-secondary/10 to-transparent',
+  'from-accent/70 via-accent/10 to-transparent',
+  'from-primary/50 via-secondary/20 to-transparent'
 ] as const;
 
 const HomePage = (): JSX.Element => {
@@ -91,83 +159,121 @@ const HomePage = (): JSX.Element => {
   const topSkills = useMemo(() => skills.slice(0, 6), [skills]);
 
   return (
-    <div className="relative space-y-24 pb-20">
-      <div className="pointer-events-none absolute inset-x-0 -top-24 -z-10 mx-auto h-[420px] max-w-5xl rounded-full bg-gradient-to-br from-primary/20 via-transparent to-secondary/20 blur-3xl" />
+    <div className="relative space-y-24 pb-24">
+      <div className="pointer-events-none absolute inset-x-0 -top-32 -z-10 mx-auto h-[520px] max-w-6xl rounded-full bg-gradient-to-br from-primary/20 via-transparent to-accent/20 blur-3xl" />
 
-      <section className="grid gap-10 pt-6 lg:grid-cols-[1.45fr,1fr] lg:items-center">
-        <Reveal className="space-y-8">
-          <span className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-sm font-medium tracking-wide text-primary">
-            {role} · Disponible para nuevos retos
-          </span>
-          <div className="space-y-4">
-            <h1 className="text-4xl font-bold leading-tight text-base-content md:text-5xl lg:text-6xl">{heroTitle}</h1>
-            <p className="text-lg text-base-content/70 md:text-xl">{heroSubtitle}</p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Link to={ctaPrimary.href} className={buttonStyles('primary', 'lg')}>
-              {ctaPrimary.label}
-            </Link>
-            <Link to={ctaSecondary.href} className={buttonStyles('secondary', 'lg')}>
-              {ctaSecondary.label}
-            </Link>
-          </div>
-          <ul className="grid gap-4 sm:grid-cols-3">
-            {designPillars.map((pillar) => (
-              <li key={pillar} className="group relative overflow-hidden rounded-2xl border border-base-200/60 bg-base-100/80 p-4 shadow-sm">
-                <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/15 via-transparent to-secondary/20 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-                <p className="text-sm font-medium text-base-content/80">{pillar}</p>
-              </li>
-            ))}
-          </ul>
-        </Reveal>
-        <Float duration={7000} amplitude={16} className="mx-auto w-full max-w-md">
-          <div className="relative overflow-hidden rounded-[2.75rem] border border-base-200/70 bg-base-100/95 p-8 shadow-xl shadow-primary/10">
-            <div className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-gradient-to-br from-primary/30 to-secondary/40 blur-2xl" aria-hidden="true" />
-            <div className="absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-gradient-to-br from-secondary/30 to-primary/20 blur-2xl" aria-hidden="true" />
-            <div className="relative space-y-4">
-              <p className="inline-flex items-center rounded-full bg-base-100/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
-                Experiencias inmersivas
-              </p>
-              <h2 className="text-2xl font-semibold text-base-content">Diseño centrado en micro-interacciones</h2>
-              <p className="text-base-content/70">
-                Arquitectura escalable, accesibilidad pragmática y animaciones con intención. Cada detalle del journey está diseñado para activar emoción y claridad desde el primer scroll.
-              </p>
-              <ul className="space-y-3 text-sm text-base-content/70">
-                <li className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-primary" /> Sistemas de diseño componibles y documentados
-                </li>
-                <li className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-secondary" /> Performance, métricas y observabilidad integradas
-                </li>
-                <li className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-accent" /> Animaciones fluidas con foco en UX y accesibilidad
-                </li>
-              </ul>
+      <section className="relative overflow-hidden rounded-[3rem] border border-base-200/60 bg-base-100/80 p-10 shadow-[0_32px_120px_-60px_rgba(99,102,241,0.65)] backdrop-blur lg:p-16">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.28),transparent_55%)]" aria-hidden="true" />
+        <div className="pointer-events-none absolute inset-y-0 right-10 w-px bg-gradient-to-b from-transparent via-base-200/60 to-transparent" aria-hidden="true" />
+        <div className="grid gap-12 lg:grid-cols-[1.3fr,1fr] lg:items-center">
+          <Reveal className="space-y-8">
+            <div className="inline-flex items-center gap-3 rounded-full border border-base-200/60 bg-base-100/90 px-5 py-2 text-sm font-medium text-base-content/70 shadow-sm">
+              <span className="h-2.5 w-2.5 rounded-full bg-gradient-to-br from-primary to-accent shadow-[0_0_0_4px_rgba(99,102,241,0.15)]" />
+              {role} · disponible para colaborar
             </div>
-          </div>
-        </Float>
+            <div className="space-y-4">
+              <h1 className="text-4xl font-bold leading-tight text-base-content md:text-5xl lg:text-6xl">{heroTitle}</h1>
+              <p className="max-w-2xl text-lg text-base-content/70 md:text-xl">{heroSubtitle}</p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link to={ctaPrimary.href} className={buttonStyles('primary', 'lg')}>
+                {ctaPrimary.label}
+              </Link>
+              <Link to={ctaSecondary.href} className={buttonStyles('secondary', 'lg')}>
+                {ctaSecondary.label}
+              </Link>
+            </div>
+            <ul className="grid gap-4 sm:grid-cols-3">
+              {heroHighlights.map((highlight) => (
+                <li
+                  key={highlight.id}
+                  className="group relative overflow-hidden rounded-2xl border border-base-200/60 bg-base-100/80 p-5 shadow-sm"
+                >
+                  <div
+                    className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-transparent to-accent/20 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                    aria-hidden="true"
+                  />
+                  <h3 className="text-sm font-semibold text-base-content">{highlight.title}</h3>
+                  <p className="mt-2 text-xs text-base-content/60">{highlight.description}</p>
+                </li>
+              ))}
+            </ul>
+          </Reveal>
+          <Float duration={6800} amplitude={18} className="mx-auto w-full max-w-md">
+            <div className="relative overflow-hidden rounded-[2.75rem] border border-base-200/70 bg-base-100/90 p-8 shadow-xl shadow-primary/15 backdrop-blur">
+              <div className="absolute -left-20 top-1/3 h-56 w-56 rounded-full bg-gradient-to-br from-primary/30 to-secondary/40 blur-3xl" aria-hidden="true" />
+              <div className="absolute -bottom-16 right-0 h-52 w-52 rounded-full bg-gradient-to-br from-accent/30 to-primary/25 blur-3xl" aria-hidden="true" />
+              <div className="relative space-y-6">
+                <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.35em] text-base-content/60">
+                  <span>Experience Radar</span>
+                  <span className="inline-flex items-center gap-2 rounded-full bg-base-200/70 px-3 py-1 text-[0.7rem] text-base-content/70">
+                    <span className="relative flex h-2 w-2">
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60" />
+                      <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+                    </span>
+                    En vivo
+                  </span>
+                </div>
+                <p className="text-2xl font-semibold text-base-content">
+                  Diseño + código para activar productos memorables y medibles.
+                </p>
+                <p className="text-sm text-base-content/70">
+                  Observabilidad, motion y accesibilidad integradas desde el primer prototipo hasta el release.
+                </p>
+                <div className="grid gap-4 sm:grid-cols-3">
+                  {heroSignals.map((signal) => (
+                    <div
+                      key={signal.id}
+                      className="relative overflow-hidden rounded-2xl border border-base-200/60 bg-base-100/85 p-4 shadow-sm"
+                    >
+                      <div className={cn('absolute inset-0 -z-10 bg-gradient-to-br opacity-60', signal.glowClass)} aria-hidden="true" />
+                      <span className={cn('inline-flex items-center rounded-full px-2.5 py-1 text-[0.7rem] font-semibold uppercase tracking-wide', signal.badgeClass)}>
+                        {signal.label}
+                      </span>
+                      <p className="mt-3 text-2xl font-semibold text-base-content">{signal.value}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Float>
+        </div>
       </section>
 
-      <section className="space-y-10">
-        <Reveal className="space-y-4">
-          <h2 className="text-3xl font-semibold text-base-content">Impacto medible en cada entrega</h2>
-          <p className="max-w-2xl text-base text-base-content/70">
-            Cada iniciativa se planifica con métricas de negocio y experiencia. Estos son algunos de los resultados recurrentes al diseñar productos centrados en las personas.
-          </p>
+      <section className="grid gap-12 lg:grid-cols-[1.1fr,1fr] lg:items-start">
+        <Reveal className="space-y-6">
+          <div className="space-y-3">
+            <h2 className="text-3xl font-semibold text-base-content">Laboratorio de impacto</h2>
+            <p className="max-w-xl text-base text-base-content/70">
+              Conecto estrategia, UX research y delivery técnico para acelerar resultados. Cada iniciativa combina exploración
+              creativa con medición constante.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {innovationTracks.map((track) => (
+              <Card key={track.id} className="h-full bg-base-100/85 p-6">
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl" aria-hidden="true">
+                    {track.icon}
+                  </span>
+                  <h3 className="text-base font-semibold text-base-content">{track.title}</h3>
+                </div>
+                <p className="mt-3 text-sm text-base-content/70">{track.detail}</p>
+              </Card>
+            ))}
+          </div>
         </Reveal>
-        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-5 sm:grid-cols-2">
           {quickStats.map((stat, index) => (
-            <Reveal key={stat.id} delay={index * 80}>
-              <ScaleOnHover className="h-full">
-                <Card className="flex h-full flex-col justify-between bg-base-100/80 p-6 backdrop-blur">
-                  <div className="space-y-4">
-                    <span className="text-4xl font-semibold text-base-content">{stat.value}</span>
-                    <h3 className="text-lg font-semibold text-base-content/90">{stat.label}</h3>
-                    <p className="text-sm text-base-content/70">{stat.description}</p>
-                  </div>
-                  <div className="mt-6 h-1 rounded-full bg-gradient-to-r from-primary/70 via-secondary/70 to-accent/70" />
-                </Card>
-              </ScaleOnHover>
+            <Reveal key={stat.id} delay={index * 90}>
+              <Card className="relative h-full overflow-hidden bg-base-100/85 p-6">
+                <div className={cn('pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br opacity-70', accentGradients[index % accentGradients.length])} aria-hidden="true" />
+                <div className="space-y-3">
+                  <span className="text-4xl font-semibold text-base-content">{stat.value}</span>
+                  <h3 className="text-lg font-semibold text-base-content/90">{stat.label}</h3>
+                  <p className="text-sm text-base-content/70">{stat.description}</p>
+                </div>
+              </Card>
             </Reveal>
           ))}
         </div>
@@ -175,7 +281,12 @@ const HomePage = (): JSX.Element => {
 
       <section className="space-y-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Proyectos recientes</h2></Reveal>
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Proyectos recientes</h2>
+            <p className="max-w-xl text-sm text-base-content/60">
+              Experimentos convertidos en productos listos para escalar: SaaS B2B, plataformas educativas y experiencias XR.
+            </p>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/projects" className={buttonStyles('ghost', 'sm')}>
               Ver todos
@@ -184,29 +295,30 @@ const HomePage = (): JSX.Element => {
         </div>
         <div className="grid gap-8 md:grid-cols-2">
           {highlightProjects.map((project, index) => (
-            <Reveal key={project.id} delay={index * 120}>
+            <Reveal key={project.id} delay={index * 140}>
               <ProjectCard project={project} />
             </Reveal>
           ))}
         </div>
       </section>
 
-      <section className="space-y-8">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Experiencia destacada</h2></Reveal>
-          <Reveal delay={120}>
-            <Link to="/about" className={buttonStyles('ghost', 'sm')}>
-              Ver trayectoria completa
-            </Link>
-          </Reveal>
-        </div>
-        <div className="relative">
-          <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-base-100 to-transparent" aria-hidden="true" />
-          <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-base-100 to-transparent" aria-hidden="true" />
-          <div className="flex snap-x gap-6 overflow-x-auto pb-6 pr-6 sm:pr-0">
+      <section className="grid gap-12 lg:grid-cols-[0.9fr,1.1fr] lg:items-start">
+        <Reveal className="space-y-4">
+          <h2 className="text-3xl font-semibold text-base-content">Trayectoria selecta</h2>
+          <p className="max-w-md text-sm text-base-content/70">
+            Liderando squads y diseñando productos end-to-end para fintech, edtech y startups en expansión.
+          </p>
+          <Link to="/about" className={buttonStyles('ghost', 'sm')}>
+            Ver trayectoria completa
+          </Link>
+        </Reveal>
+        <div className="relative pl-6">
+          <div className="pointer-events-none absolute left-0 top-1 hidden h-full w-px bg-gradient-to-b from-primary/40 via-base-200 to-transparent sm:block" aria-hidden="true" />
+          <div className="flex snap-x gap-6 overflow-x-auto pb-6 pr-6 sm:grid sm:grid-cols-2 sm:gap-6 sm:overflow-visible sm:pr-0">
             {experienceTimeline.map((item, index) => (
-              <Reveal key={item.id} delay={index * 80} className="min-w-[280px] snap-center">
-                <Card className="h-full bg-base-100/80 p-6">
+              <Reveal key={item.id} delay={index * 120} className="min-w-[280px] snap-center">
+                <Card className="relative h-full border-base-200/70 bg-base-100/85 p-6">
+                  <span className="absolute -left-3 top-6 hidden h-6 w-6 rounded-full bg-gradient-to-br from-primary to-accent shadow-lg shadow-primary/30 ring-4 ring-base-100 sm:flex" aria-hidden="true" />
                   <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/80">{item.period}</p>
                   <h3 className="mt-4 text-lg font-semibold text-base-content">{item.title}</h3>
                   <p className="mt-3 text-sm text-base-content/70">{item.description}</p>
@@ -219,7 +331,12 @@ const HomePage = (): JSX.Element => {
 
       <section className="space-y-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Últimas publicaciones</h2></Reveal>
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Bitácora de aprendizajes</h2>
+            <p className="max-w-xl text-sm text-base-content/60">
+              Estrategias de producto, insights de investigación y notas sobre motion y accesibilidad.
+            </p>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/posts" className={buttonStyles('ghost', 'sm')}>
               Leer más
@@ -228,7 +345,7 @@ const HomePage = (): JSX.Element => {
         </div>
         <div className="grid gap-8 md:grid-cols-3">
           {latestPosts.map((post, index) => (
-            <Reveal key={post.id} delay={index * 120}>
+            <Reveal key={post.id} delay={index * 160}>
               <PostCard post={post} />
             </Reveal>
           ))}
@@ -237,16 +354,17 @@ const HomePage = (): JSX.Element => {
 
       <section className="space-y-10">
         <Reveal className="space-y-3">
-          <h2 className="text-3xl font-semibold text-base-content">Un proceso pensado para sorprender</h2>
+          <h2 className="text-3xl font-semibold text-base-content">Framework de co-creación</h2>
           <p className="max-w-2xl text-base text-base-content/70">
-            Desde el primer contacto hasta el lanzamiento, diseño experiencias memorables y coherentes. Así conecto estrategia, diseño y ejecución.
+            Una cadencia clara para pasar de los hallazgos al release con seguridad. Cada fase mantiene a negocio, diseño y
+            tecnología alineados.
           </p>
         </Reveal>
         <div className="grid gap-6 md:grid-cols-3">
           {processTimeline.map((step, index) => (
-            <Reveal key={step.id} delay={index * 120}>
+            <Reveal key={step.id} delay={index * 130}>
               <ScaleOnHover className="h-full">
-                <Card className="flex h-full flex-col justify-between bg-base-100/85 p-6">
+                <Card className="flex h-full flex-col justify-between border-base-200/70 bg-base-100/85 p-6">
                   <div className="space-y-4">
                     <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
                       Fase {step.id}
@@ -255,7 +373,7 @@ const HomePage = (): JSX.Element => {
                     <p className="text-sm text-base-content/70">{step.description}</p>
                   </div>
                   <div className="mt-6 flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-base-content/60">
-                    <span>Resultado</span>
+                    <span>Entrega</span>
                     <span className="text-primary">{step.outcome}</span>
                   </div>
                 </Card>
@@ -267,7 +385,12 @@ const HomePage = (): JSX.Element => {
 
       <section className="space-y-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
-          <Reveal><h2 className="text-3xl font-semibold text-base-content">Stack principal</h2></Reveal>
+          <Reveal>
+            <h2 className="text-3xl font-semibold text-base-content">Stack core</h2>
+            <p className="max-w-xl text-sm text-base-content/60">
+              Herramientas y tecnologías que utilizo para diseñar, prototipar y desplegar experiencias digitales.
+            </p>
+          </Reveal>
           <Reveal delay={120}>
             <Link to="/skills" className={buttonStyles('ghost', 'sm')}>
               Ver todas las skills
@@ -283,12 +406,13 @@ const HomePage = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="relative overflow-hidden rounded-3xl border border-primary/10 bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 p-10 text-base-content shadow-xl">
-        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.25),transparent_60%)]" aria-hidden="true" />
+      <section className="relative overflow-hidden rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/15 via-base-100 to-secondary/15 p-12 text-base-content shadow-[0_40px_140px_-90px_rgba(59,130,246,0.65)]">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,rgba(99,102,241,0.4),transparent_60%)]" aria-hidden="true" />
         <Reveal className="space-y-6">
-          <h2 className="text-3xl font-semibold md:text-4xl">¿Listo para elevar la siguiente experiencia digital?</h2>
+          <h2 className="text-3xl font-semibold md:text-4xl">¿Listo para activar la próxima experiencia digital?</h2>
           <p className="max-w-3xl text-base-content/70 md:text-lg">
-            Conecto estrategia, diseño y código para lanzar productos memorables. Hablemos sobre cómo podemos construir algo extraordinario para tu audiencia.
+            Transformemos ideas en productos listos para crecer. Podemos co-crear una visión clara, prototipos medibles y un
+            plan de entrega impecable.
           </p>
           <div className="flex flex-wrap gap-3">
             <Link to="/contact" className={buttonStyles('primary', 'lg')}>

--- a/src/widgets/Footer.tsx
+++ b/src/widgets/Footer.tsx
@@ -4,17 +4,18 @@ import { navItems } from './navItems';
 
 const Footer = (): JSX.Element => {
   return (
-    <footer className="border-t border-base-200 bg-base-100/80">
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-base-content/70 md:flex-row md:items-center md:justify-between md:px-8">
+    <footer className="relative mt-10 border-t border-base-200/70 bg-base-100/80">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.18),transparent_65%)]" aria-hidden="true" />
+      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-5 py-12 text-sm text-base-content/70 md:flex-row md:items-center md:justify-between md:px-10">
         <div>
-          <p className="font-semibold text-base-content">Laura Méndez · Frontend Engineer</p>
-          <p className="mt-2 max-w-md">
-            Construyendo productos digitales que combinan narrativa visual, ingeniería sólida y experiencias accesibles.
+          <p className="text-base font-semibold text-base-content">Laura Méndez · Frontend Engineer</p>
+          <p className="mt-2 max-w-md text-sm">
+            Diseño productos donde la tecnología se siente humana: research, visual storytelling y entrega técnica lista para escalar.
           </p>
         </div>
-        <nav className="flex flex-wrap gap-3 text-base-content/70">
+        <nav className="flex flex-wrap gap-4 text-base-content/70">
           {navItems.map((item) => (
-            <Link key={item.to} to={item.to} className="hover:text-primary">
+            <Link key={item.to} to={item.to} className="rounded-lg px-2 py-1 transition hover:bg-primary/10 hover:text-primary">
               {item.label}
             </Link>
           ))}
@@ -24,7 +25,7 @@ const Footer = (): JSX.Element => {
           <p className="font-medium text-base-content">hola@lauramendez.dev</p>
         </div>
       </div>
-      <div className="border-t border-base-200/80 bg-base-200/50 py-4 text-center text-xs text-base-content/60">
+      <div className="border-t border-base-200/60 bg-base-200/40 py-4 text-center text-xs text-base-content/60">
         © {new Date().getFullYear()} Laura Méndez. Diseñado con cariño y código.
       </div>
     </footer>

--- a/src/widgets/Navbar.tsx
+++ b/src/widgets/Navbar.tsx
@@ -12,28 +12,31 @@ const Navbar = (): JSX.Element => {
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-base-200/80 bg-base-100/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 md:px-8">
-        <Link to="/" className="flex items-center gap-2 text-lg font-semibold">
-          <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-lg shadow-primary/30">
+    <header className="fixed inset-x-0 top-0 z-40">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-full bg-gradient-to-b from-base-100/95 to-base-100/70 backdrop-blur-xl" aria-hidden="true" />
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-5 py-4 md:px-10">
+        <Link to="/" className="flex items-center gap-3 text-lg font-semibold">
+          <span className="relative inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-primary-foreground shadow-lg shadow-primary/30">
+            <span className="absolute inset-0 rounded-2xl border border-white/30 opacity-40" aria-hidden="true" />
             LM
           </span>
-          <span className="hidden sm:inline">Laura Méndez</span>
+          <span className="hidden sm:inline text-base-content">Laura Méndez</span>
         </Link>
-        <nav className="hidden items-center gap-1 rounded-2xl border border-base-200 bg-base-100/80 px-2 py-1 shadow-sm md:flex">
+        <nav className="hidden items-center gap-1 rounded-2xl border border-base-200/70 bg-base-100/80 px-2 py-1 shadow-sm shadow-primary/10 backdrop-blur md:flex">
           {navItems.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}
               className={({ isActive }) =>
                 cn(
-                  'rounded-xl px-3 py-2 text-sm font-medium text-base-content/70 transition hover:bg-base-200',
-                  isActive && 'bg-base-200 text-base-content'
+                  'relative overflow-hidden rounded-xl px-3 py-2 text-sm font-medium text-base-content/70 transition',
+                  'hover:bg-base-200/80 hover:text-base-content',
+                  isActive && 'bg-base-200/80 text-base-content shadow-inner shadow-primary/10'
                 )
               }
               end={item.to === '/'}
             >
-              {item.label}
+              <span className="relative z-10">{item.label}</span>
             </NavLink>
           ))}
         </nav>
@@ -52,7 +55,7 @@ const Navbar = (): JSX.Element => {
           </button>
         </div>
       </div>
-      <div className="px-4 pb-4 md:hidden">
+      <div className="px-5 pb-4 md:hidden">
         <SearchBar />
       </div>
     </header>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,10 +15,17 @@ const config: Config = {
           DEFAULT: '#6366f1',
           foreground: '#ffffff'
         },
+        secondary: {
+          DEFAULT: '#22d3ee',
+          foreground: '#0f172a'
+        },
         accent: {
           DEFAULT: '#f97316',
           foreground: '#0f172a'
         }
+      },
+      backgroundImage: {
+        'grid-signal': 'linear-gradient(90deg, rgba(99,102,241,0.08) 1px, transparent 1px), linear-gradient(180deg, rgba(99,102,241,0.08) 1px, transparent 1px)'
       }
     }
   },


### PR DESCRIPTION
## Summary
- rediseñé la home con un hero inmersivo, nuevas métricas interactivas y secciones reordenadas para una narrativa más dinámica.
- actualicé el layout general, navbar, footer y fondos globales para reforzar la estética tecnológica con gradientes y efecto grid.
- amplié la paleta de colores de Tailwind para incorporar un nuevo tono secundario acorde al nuevo estilo.

## Testing
- npm run build *(falla: npm install bloqueado por error 403 al descargar @types/node, impidió completar la compilación)*

------
https://chatgpt.com/codex/tasks/task_e_68d446a5f034832e9af2b2489aec51f3