### PR TITLE
feat: scaffold liquidaciones module UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# portafoliov2
+# Liquidación de Asignaciones
+
+Este proyecto contiene la fase inicial (UI estática) del módulo de **Liquidación de Asignaciones a Asociaciones** construido con React 19, Vite, TailwindCSS y DaisyUI.
+
+## Scripts disponibles
+
+- `pnpm dev` / `npm run dev`: levanta el entorno de desarrollo.
+- `pnpm build` / `npm run build`: compila la aplicación.
+- `pnpm preview` / `npm run preview`: sirve la aplicación compilada.
+
+## Estructura principal
+
+El proyecto sigue una arquitectura modular basada en features:
+
+```
+src/
+├── components/
+├── features/
+│   └── liquidaciones/
+│       ├── components/
+│       ├── hooks/
+│       ├── mock/
+│       ├── pages/
+│       ├── services/
+│       └── stores/
+└── services/
+```
+
+La fase 1 maqueta la vista `/liquidaciones` con datos mock y componentes reutilizables listos para las siguientes fases de integración y validaciones.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Liquidación de Asignaciones
 
-Este proyecto contiene la fase inicial (UI estática) del módulo de **Liquidación de Asignaciones a Asociaciones** construido con React 19, Vite, TailwindCSS y DaisyUI.
+Este proyecto contiene el módulo de **Liquidación de Asignaciones a Asociaciones** construido con React 19, Vite, TailwindCSS y DaisyUI.
+
+Actualmente se han completado las fases de maquetación y la integración inicial con servicios HTTP (GET/POST/PUT) utilizando Axios y un backend simulado con `axios-mock-adapter` para facilitar el desarrollo local.
 
 ## Scripts disponibles
 
@@ -26,4 +28,14 @@ src/
 └── services/
 ```
 
-La fase 1 maqueta la vista `/liquidaciones` con datos mock y componentes reutilizables listos para las siguientes fases de integración y validaciones.
+### Mock API para desarrollo
+
+Para mantener el flujo de trabajo desacoplado del backend definitivo, en modo desarrollo (`npm run dev`) se habilita un mock API basado en `axios-mock-adapter` que responde a las rutas:
+
+- `GET /liquidaciones`: devuelve el listado de liquidaciones.
+- `POST /liquidaciones`: registra una nueva liquidación.
+- `PUT /liquidaciones/:id`: actualiza campos clave (monto asignado/gastado, estado, descripción).
+
+Las respuestas utilizan los datos de `src/features/liquidaciones/mock/liquidacionesData.ts`, que pueden ampliarse según las necesidades de QA o demos.
+
+Para conectar la aplicación con un backend real, define la variable de entorno `VITE_API_URL` en un archivo `.env` y la aplicación utilizará esa URL como `baseURL` por defecto para Axios.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es" data-theme="corporate">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Liquidación de Asignaciones</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "liquidacion-asignaciones",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "daisyui": "^4.12.13",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^6.26.2",
+    "zustand": "^4.5.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react-swc": "^3.5.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.10"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "axios-mock-adapter": "^2.1.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,15 @@
+import { Route, Routes } from 'react-router-dom';
+
+import { LiquidacionesPage } from './features/liquidaciones/pages/LiquidacionesPage';
+import { MainLayout } from './components/layout/MainLayout';
+
+const App = () => (
+  <MainLayout>
+    <Routes>
+      <Route path="/" element={<LiquidacionesPage />} />
+      <Route path="/liquidaciones" element={<LiquidacionesPage />} />
+    </Routes>
+  </MainLayout>
+);
+
+export default App;

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,0 +1,18 @@
+import type { PropsWithChildren } from 'react';
+import { NavLink } from 'react-router-dom';
+
+export const MainLayout = ({ children }: PropsWithChildren) => (
+  <div className="min-h-screen flex flex-col">
+    <header className="navbar bg-base-100 shadow">
+      <div className="flex-1">
+        <span className="text-xl font-semibold">Liquidación de Asignaciones</span>
+      </div>
+      <nav className="flex gap-2">
+        <NavLink className="btn btn-ghost" to="/liquidaciones">
+          Liquidaciones
+        </NavLink>
+      </nav>
+    </header>
+    <main className="flex-1 container mx-auto px-4 py-8">{children}</main>
+  </div>
+);

--- a/src/features/liquidaciones/components/LiquidacionesFiltros.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesFiltros.tsx
@@ -1,0 +1,25 @@
+export const LiquidacionesFiltros = () => (
+  <section className="rounded-box border border-base-200 bg-base-100 p-4 shadow-sm">
+    <h2 className="text-sm font-semibold text-base-content/80">Filtros rápidos</h2>
+    <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <label className="form-control w-full max-w-xs">
+        <span className="label-text mb-1">Buscar asociación</span>
+        <input className="input input-bordered input-sm" placeholder="Nombre o código" />
+      </label>
+      <label className="form-control w-full max-w-xs">
+        <span className="label-text mb-1">Estado</span>
+        <select className="select select-bordered select-sm">
+          <option value="">Todos</option>
+          <option>Pendiente</option>
+          <option>En Revisión</option>
+          <option>Aprobada</option>
+          <option>Rechazada</option>
+        </select>
+      </label>
+      <label className="form-control w-full max-w-xs">
+        <span className="label-text mb-1">Periodo</span>
+        <input className="input input-bordered input-sm" placeholder="Ej. 2024" />
+      </label>
+    </div>
+  </section>
+);

--- a/src/features/liquidaciones/components/LiquidacionesHeader.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesHeader.tsx
@@ -1,7 +1,8 @@
-import { useLiquidacionesStore } from '../stores/liquidaciones.store';
+import { useLiquidaciones } from '../hooks/useLiquidaciones';
 
 export const LiquidacionesHeader = () => {
-  const toggleModalNueva = useLiquidacionesStore((state) => state.toggleModalNueva);
+  const { toggleModalNueva, fetchLiquidaciones, fetchState } = useLiquidaciones();
+  const isRefreshing = fetchState.status === 'loading';
 
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -12,7 +13,15 @@ export const LiquidacionesHeader = () => {
         </p>
       </div>
       <div className="flex gap-2">
-        <button className="btn btn-outline btn-sm">Exportar</button>
+        <button
+          className="btn btn-outline btn-sm"
+          onClick={() => {
+            void fetchLiquidaciones();
+          }}
+          disabled={isRefreshing}
+        >
+          {isRefreshing ? <span className="loading loading-spinner" /> : 'Sincronizar'}
+        </button>
         <button className="btn btn-primary" onClick={() => toggleModalNueva(true)}>
           Nueva Liquidación
         </button>

--- a/src/features/liquidaciones/components/LiquidacionesHeader.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesHeader.tsx
@@ -1,0 +1,22 @@
+import { useLiquidacionesStore } from '../stores/liquidaciones.store';
+
+export const LiquidacionesHeader = () => {
+  const toggleModalNueva = useLiquidacionesStore((state) => state.toggleModalNueva);
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold text-base-content">Liquidaciones pendientes</h1>
+        <p className="text-base-content/70 text-sm">
+          Consulta el avance de liquidaciones por asociación y registra nuevas solicitudes.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <button className="btn btn-outline btn-sm">Exportar</button>
+        <button className="btn btn-primary" onClick={() => toggleModalNueva(true)}>
+          Nueva Liquidación
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/liquidaciones/components/LiquidacionesResumen.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesResumen.tsx
@@ -1,0 +1,28 @@
+interface LiquidacionesResumenProps {
+  totalAsignado: number;
+  totalGastado: number;
+  diferencia: number;
+}
+
+export const LiquidacionesResumen = ({ totalAsignado, totalGastado, diferencia }: LiquidacionesResumenProps) => (
+  <div className="stats shadow w-full">
+    <div className="stat">
+      <div className="stat-title">Total Asignado</div>
+      <div className="stat-value text-primary">
+        {totalAsignado.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' })}
+      </div>
+    </div>
+    <div className="stat">
+      <div className="stat-title">Total Gastado</div>
+      <div className="stat-value text-secondary">
+        {totalGastado.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' })}
+      </div>
+    </div>
+    <div className="stat">
+      <div className="stat-title">Saldo</div>
+      <div className={`stat-value ${diferencia >= 0 ? 'text-success' : 'text-error'}`}>
+        {diferencia.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' })}
+      </div>
+    </div>
+  </div>
+);

--- a/src/features/liquidaciones/components/LiquidacionesResumen.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesResumen.tsx
@@ -2,27 +2,46 @@ interface LiquidacionesResumenProps {
   totalAsignado: number;
   totalGastado: number;
   diferencia: number;
+  isLoading?: boolean;
 }
 
-export const LiquidacionesResumen = ({ totalAsignado, totalGastado, diferencia }: LiquidacionesResumenProps) => (
-  <div className="stats shadow w-full">
-    <div className="stat">
-      <div className="stat-title">Total Asignado</div>
-      <div className="stat-value text-primary">
-        {totalAsignado.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' })}
+const formatCurrency = (value: number) =>
+  value.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' });
+
+export const LiquidacionesResumen = ({
+  totalAsignado,
+  totalGastado,
+  diferencia,
+  isLoading = false
+}: LiquidacionesResumenProps) => (
+  <div className="stats w-full shadow">
+    {[
+      {
+        label: 'Total Asignado',
+        value: formatCurrency(totalAsignado),
+        className: 'text-primary'
+      },
+      {
+        label: 'Total Gastado',
+        value: formatCurrency(totalGastado),
+        className: 'text-secondary'
+      },
+      {
+        label: 'Saldo',
+        value: formatCurrency(diferencia),
+        className: diferencia >= 0 ? 'text-success' : 'text-error'
+      }
+    ].map((stat) => (
+      <div key={stat.label} className="stat">
+        <div className="stat-title">{stat.label}</div>
+        {isLoading ? (
+          <div className="stat-value">
+            <span className="skeleton h-8 w-40" />
+          </div>
+        ) : (
+          <div className={`stat-value ${stat.className}`}>{stat.value}</div>
+        )}
       </div>
-    </div>
-    <div className="stat">
-      <div className="stat-title">Total Gastado</div>
-      <div className="stat-value text-secondary">
-        {totalGastado.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' })}
-      </div>
-    </div>
-    <div className="stat">
-      <div className="stat-title">Saldo</div>
-      <div className={`stat-value ${diferencia >= 0 ? 'text-success' : 'text-error'}`}>
-        {diferencia.toLocaleString('es-PE', { style: 'currency', currency: 'PEN' })}
-      </div>
-    </div>
+    ))}
   </div>
 );

--- a/src/features/liquidaciones/components/LiquidacionesTable.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesTable.tsx
@@ -1,4 +1,4 @@
-import type { Liquidacion } from '../mock/liquidacionesData';
+import type { Liquidacion } from '../types/liquidacion';
 
 const estadoBadgeStyles: Record<Liquidacion['estado'], string> = {
   Pendiente: 'badge-warning',
@@ -9,48 +9,80 @@ const estadoBadgeStyles: Record<Liquidacion['estado'], string> = {
 
 interface LiquidacionesTableProps {
   data: Liquidacion[];
+  isLoading?: boolean;
 }
 
-export const LiquidacionesTable = ({ data }: LiquidacionesTableProps) => (
-  <div className="overflow-x-auto rounded-box border border-base-200 bg-base-100 shadow-sm">
-    <table className="table">
-      <thead>
-        <tr>
-          <th>Asociación</th>
-          <th>Periodo</th>
-          <th className="text-right">Monto Asignado</th>
-          <th className="text-right">Monto Gastado</th>
-          <th className="text-center">Estado</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map((liquidacion) => (
-          <tr key={liquidacion.id}>
-            <td>
-              <div className="font-medium text-base-content/90">{liquidacion.asociacion}</div>
-              <div className="text-sm text-base-content/60">{liquidacion.id}</div>
-            </td>
-            <td>{liquidacion.periodo}</td>
-            <td className="text-right font-semibold">
-              {liquidacion.montoAsignado.toLocaleString('es-PE', {
-                style: 'currency',
-                currency: 'PEN'
-              })}
-            </td>
-            <td className="text-right">
-              {liquidacion.montoGastado.toLocaleString('es-PE', {
-                style: 'currency',
-                currency: 'PEN'
-              })}
-            </td>
-            <td className="text-center">
-              <span className={`badge ${estadoBadgeStyles[liquidacion.estado]}`}>
-                {liquidacion.estado}
-              </span>
-            </td>
+export const LiquidacionesTable = ({ data, isLoading = false }: LiquidacionesTableProps) => {
+  if (isLoading) {
+    return (
+      <div className="overflow-hidden rounded-box border border-base-200 bg-base-100 p-6 shadow-sm">
+        <div className="flex flex-col gap-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="flex items-center justify-between">
+              <span className="skeleton h-4 w-32" />
+              <span className="skeleton h-4 w-24" />
+              <span className="skeleton h-4 w-24" />
+              <span className="skeleton h-4 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data.length) {
+    return (
+      <div className="rounded-box border border-dashed border-base-200 bg-base-100 p-10 text-center shadow-sm">
+        <h3 className="text-lg font-semibold text-base-content">Sin liquidaciones registradas</h3>
+        <p className="mt-2 text-sm text-base-content/70">
+          Aún no se han registrado liquidaciones para las asociaciones. Usa el botón "Nueva Liquidación" para crear una
+          solicitud.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-box border border-base-200 bg-base-100 shadow-sm">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Asociación</th>
+            <th>Periodo</th>
+            <th className="text-right">Monto Asignado</th>
+            <th className="text-right">Monto Gastado</th>
+            <th className="text-center">Estado</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
-  </div>
-);
+        </thead>
+        <tbody>
+          {data.map((liquidacion) => (
+            <tr key={liquidacion.id}>
+              <td>
+                <div className="font-medium text-base-content/90">{liquidacion.asociacion}</div>
+                <div className="text-sm text-base-content/60">{liquidacion.id}</div>
+              </td>
+              <td>{liquidacion.periodo}</td>
+              <td className="text-right font-semibold">
+                {liquidacion.montoAsignado.toLocaleString('es-PE', {
+                  style: 'currency',
+                  currency: 'PEN'
+                })}
+              </td>
+              <td className="text-right">
+                {liquidacion.montoGastado.toLocaleString('es-PE', {
+                  style: 'currency',
+                  currency: 'PEN'
+                })}
+              </td>
+              <td className="text-center">
+                <span className={`badge ${estadoBadgeStyles[liquidacion.estado]}`}>
+                  {liquidacion.estado}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/features/liquidaciones/components/LiquidacionesTable.tsx
+++ b/src/features/liquidaciones/components/LiquidacionesTable.tsx
@@ -1,0 +1,56 @@
+import type { Liquidacion } from '../mock/liquidacionesData';
+
+const estadoBadgeStyles: Record<Liquidacion['estado'], string> = {
+  Pendiente: 'badge-warning',
+  'En Revisión': 'badge-info',
+  Aprobada: 'badge-success',
+  Rechazada: 'badge-error'
+};
+
+interface LiquidacionesTableProps {
+  data: Liquidacion[];
+}
+
+export const LiquidacionesTable = ({ data }: LiquidacionesTableProps) => (
+  <div className="overflow-x-auto rounded-box border border-base-200 bg-base-100 shadow-sm">
+    <table className="table">
+      <thead>
+        <tr>
+          <th>Asociación</th>
+          <th>Periodo</th>
+          <th className="text-right">Monto Asignado</th>
+          <th className="text-right">Monto Gastado</th>
+          <th className="text-center">Estado</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((liquidacion) => (
+          <tr key={liquidacion.id}>
+            <td>
+              <div className="font-medium text-base-content/90">{liquidacion.asociacion}</div>
+              <div className="text-sm text-base-content/60">{liquidacion.id}</div>
+            </td>
+            <td>{liquidacion.periodo}</td>
+            <td className="text-right font-semibold">
+              {liquidacion.montoAsignado.toLocaleString('es-PE', {
+                style: 'currency',
+                currency: 'PEN'
+              })}
+            </td>
+            <td className="text-right">
+              {liquidacion.montoGastado.toLocaleString('es-PE', {
+                style: 'currency',
+                currency: 'PEN'
+              })}
+            </td>
+            <td className="text-center">
+              <span className={`badge ${estadoBadgeStyles[liquidacion.estado]}`}>
+                {liquidacion.estado}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);

--- a/src/features/liquidaciones/components/NuevaLiquidacionModal.tsx
+++ b/src/features/liquidaciones/components/NuevaLiquidacionModal.tsx
@@ -1,17 +1,52 @@
-import { useLiquidacionesStore } from '../stores/liquidaciones.store';
+import { FormEvent, useState } from 'react';
+
+import { useLiquidaciones } from '../hooks/useLiquidaciones';
+
+const initialFormState = {
+  asociacion: '',
+  periodo: '',
+  montoAsignado: '',
+  descripcion: ''
+};
 
 export const NuevaLiquidacionModal = () => {
-  const mostrarModalNueva = useLiquidacionesStore((state) => state.mostrarModalNueva);
-  const toggleModalNueva = useLiquidacionesStore((state) => state.toggleModalNueva);
+  const { mostrarModalNueva, toggleModalNueva, crearLiquidacion, mutationState } = useLiquidaciones();
+  const [formValues, setFormValues] = useState(initialFormState);
+
+  const handleClose = () => {
+    toggleModalNueva(false);
+    setFormValues(initialFormState);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const montoAsignado = Number(formValues.montoAsignado);
+
+    if (!formValues.asociacion || !formValues.periodo || Number.isNaN(montoAsignado)) {
+      return;
+    }
+
+    const nueva = await crearLiquidacion({
+      asociacion: formValues.asociacion,
+      periodo: formValues.periodo,
+      montoAsignado,
+      descripcion: formValues.descripcion,
+      montoGastado: 0,
+      estado: 'Pendiente'
+    });
+    if (nueva) {
+      setFormValues(initialFormState);
+    }
+  };
 
   return (
     <dialog className="modal" open={mostrarModalNueva}>
       <div className="modal-box max-w-2xl">
-        <h3 className="font-bold text-lg">Nueva Liquidación</h3>
+        <h3 className="text-lg font-bold">Nueva Liquidación</h3>
         <p className="py-2 text-sm text-base-content/70">
-          Esta es una maqueta de la fase 1. Los campos aún no realizan envíos reales.
+          Registra una nueva solicitud de liquidación para la asociación seleccionada.
         </p>
-        <form className="grid grid-cols-1 gap-4 mt-4">
+        <form className="grid grid-cols-1 gap-4 mt-4" onSubmit={handleSubmit}>
           <div className="form-control">
             <label className="label" htmlFor="asociacion">
               <span className="label-text">Asociación</span>
@@ -21,6 +56,11 @@ export const NuevaLiquidacionModal = () => {
               className="input input-bordered"
               placeholder="Nombre de la asociación"
               type="text"
+              value={formValues.asociacion}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, asociacion: event.target.value }))
+              }
+              required
             />
           </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -28,32 +68,70 @@ export const NuevaLiquidacionModal = () => {
               <label className="label" htmlFor="periodo">
                 <span className="label-text">Periodo</span>
               </label>
-              <input id="periodo" className="input input-bordered" placeholder="Ej. Abril 2024" />
+              <input
+                id="periodo"
+                className="input input-bordered"
+                placeholder="Ej. Abril 2024"
+                value={formValues.periodo}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, periodo: event.target.value }))
+                }
+                required
+              />
             </div>
             <div className="form-control">
               <label className="label" htmlFor="montoAsignado">
                 <span className="label-text">Monto Asignado (S/)</span>
               </label>
-              <input id="montoAsignado" className="input input-bordered" type="number" min="0" step="0.01" />
+              <input
+                id="montoAsignado"
+                className="input input-bordered"
+                type="number"
+                min="0"
+                step="0.01"
+                value={formValues.montoAsignado}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, montoAsignado: event.target.value }))
+                }
+                required
+              />
             </div>
           </div>
           <div className="form-control">
             <label className="label" htmlFor="descripcion">
               <span className="label-text">Descripción</span>
             </label>
-            <textarea id="descripcion" className="textarea textarea-bordered" rows={3} placeholder="Resumen del uso de la asignación" />
+            <textarea
+              id="descripcion"
+              className="textarea textarea-bordered"
+              rows={3}
+              placeholder="Resumen del uso de la asignación"
+              value={formValues.descripcion}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, descripcion: event.target.value }))
+              }
+            />
+          </div>
+          {mutationState.status === 'error' && (
+            <div className="alert alert-error">
+              <span>{mutationState.error}</span>
+            </div>
+          )}
+          <div className="modal-action">
+            <button className="btn btn-ghost" type="button" onClick={handleClose}>
+              Cancelar
+            </button>
+            <button className="btn btn-primary" type="submit" disabled={mutationState.status === 'loading'}>
+              {mutationState.status === 'loading' ? (
+                <span className="loading loading-spinner" />
+              ) : (
+                'Guardar Borrador'
+              )}
+            </button>
           </div>
         </form>
-        <div className="modal-action">
-          <button className="btn btn-ghost" type="button" onClick={() => toggleModalNueva(false)}>
-            Cancelar
-          </button>
-          <button className="btn btn-primary" type="button">
-            Guardar Borrador
-          </button>
-        </div>
       </div>
-      <form method="dialog" className="modal-backdrop" onSubmit={() => toggleModalNueva(false)}>
+      <form method="dialog" className="modal-backdrop" onSubmit={handleClose}>
         <button type="submit">close</button>
       </form>
     </dialog>

--- a/src/features/liquidaciones/components/NuevaLiquidacionModal.tsx
+++ b/src/features/liquidaciones/components/NuevaLiquidacionModal.tsx
@@ -1,0 +1,61 @@
+import { useLiquidacionesStore } from '../stores/liquidaciones.store';
+
+export const NuevaLiquidacionModal = () => {
+  const mostrarModalNueva = useLiquidacionesStore((state) => state.mostrarModalNueva);
+  const toggleModalNueva = useLiquidacionesStore((state) => state.toggleModalNueva);
+
+  return (
+    <dialog className="modal" open={mostrarModalNueva}>
+      <div className="modal-box max-w-2xl">
+        <h3 className="font-bold text-lg">Nueva Liquidación</h3>
+        <p className="py-2 text-sm text-base-content/70">
+          Esta es una maqueta de la fase 1. Los campos aún no realizan envíos reales.
+        </p>
+        <form className="grid grid-cols-1 gap-4 mt-4">
+          <div className="form-control">
+            <label className="label" htmlFor="asociacion">
+              <span className="label-text">Asociación</span>
+            </label>
+            <input
+              id="asociacion"
+              className="input input-bordered"
+              placeholder="Nombre de la asociación"
+              type="text"
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="form-control">
+              <label className="label" htmlFor="periodo">
+                <span className="label-text">Periodo</span>
+              </label>
+              <input id="periodo" className="input input-bordered" placeholder="Ej. Abril 2024" />
+            </div>
+            <div className="form-control">
+              <label className="label" htmlFor="montoAsignado">
+                <span className="label-text">Monto Asignado (S/)</span>
+              </label>
+              <input id="montoAsignado" className="input input-bordered" type="number" min="0" step="0.01" />
+            </div>
+          </div>
+          <div className="form-control">
+            <label className="label" htmlFor="descripcion">
+              <span className="label-text">Descripción</span>
+            </label>
+            <textarea id="descripcion" className="textarea textarea-bordered" rows={3} placeholder="Resumen del uso de la asignación" />
+          </div>
+        </form>
+        <div className="modal-action">
+          <button className="btn btn-ghost" type="button" onClick={() => toggleModalNueva(false)}>
+            Cancelar
+          </button>
+          <button className="btn btn-primary" type="button">
+            Guardar Borrador
+          </button>
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop" onSubmit={() => toggleModalNueva(false)}>
+        <button type="submit">close</button>
+      </form>
+    </dialog>
+  );
+};

--- a/src/features/liquidaciones/hooks/useLiquidaciones.ts
+++ b/src/features/liquidaciones/hooks/useLiquidaciones.ts
@@ -1,11 +1,26 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useLiquidacionesStore } from '../stores/liquidaciones.store';
 
-export const useLiquidaciones = () => {
+interface UseLiquidacionesOptions {
+  autoFetch?: boolean;
+}
+
+export const useLiquidaciones = ({ autoFetch = false }: UseLiquidacionesOptions = {}) => {
   const liquidaciones = useLiquidacionesStore((state) => state.liquidaciones);
   const mostrarModalNueva = useLiquidacionesStore((state) => state.mostrarModalNueva);
   const toggleModalNueva = useLiquidacionesStore((state) => state.toggleModalNueva);
+  const fetchState = useLiquidacionesStore((state) => state.fetchState);
+  const mutationState = useLiquidacionesStore((state) => state.mutationState);
+  const fetchLiquidaciones = useLiquidacionesStore((state) => state.fetchLiquidaciones);
+  const crearLiquidacion = useLiquidacionesStore((state) => state.crearLiquidacion);
+  const actualizarLiquidacion = useLiquidacionesStore((state) => state.actualizarLiquidacion);
+
+  useEffect(() => {
+    if (autoFetch && fetchState.status === 'idle') {
+      void fetchLiquidaciones();
+    }
+  }, [autoFetch, fetchState.status, fetchLiquidaciones]);
 
   const resumen = useMemo(() => {
     const totalAsignado = liquidaciones.reduce((acc, item) => acc + item.montoAsignado, 0);
@@ -20,8 +35,13 @@ export const useLiquidaciones = () => {
 
   return {
     liquidaciones,
+    resumen,
     mostrarModalNueva,
     toggleModalNueva,
-    resumen
+    fetchState,
+    mutationState,
+    fetchLiquidaciones,
+    crearLiquidacion,
+    actualizarLiquidacion
   };
 };

--- a/src/features/liquidaciones/hooks/useLiquidaciones.ts
+++ b/src/features/liquidaciones/hooks/useLiquidaciones.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+import { useLiquidacionesStore } from '../stores/liquidaciones.store';
+
+export const useLiquidaciones = () => {
+  const liquidaciones = useLiquidacionesStore((state) => state.liquidaciones);
+  const mostrarModalNueva = useLiquidacionesStore((state) => state.mostrarModalNueva);
+  const toggleModalNueva = useLiquidacionesStore((state) => state.toggleModalNueva);
+
+  const resumen = useMemo(() => {
+    const totalAsignado = liquidaciones.reduce((acc, item) => acc + item.montoAsignado, 0);
+    const totalGastado = liquidaciones.reduce((acc, item) => acc + item.montoGastado, 0);
+
+    return {
+      totalAsignado,
+      totalGastado,
+      diferencia: totalAsignado - totalGastado
+    };
+  }, [liquidaciones]);
+
+  return {
+    liquidaciones,
+    mostrarModalNueva,
+    toggleModalNueva,
+    resumen
+  };
+};

--- a/src/features/liquidaciones/mock/liquidacionesData.ts
+++ b/src/features/liquidaciones/mock/liquidacionesData.ts
@@ -1,13 +1,4 @@
-export type EstadoLiquidacion = 'Pendiente' | 'En Revisión' | 'Aprobada' | 'Rechazada';
-
-export interface Liquidacion {
-  id: string;
-  asociacion: string;
-  montoAsignado: number;
-  montoGastado: number;
-  estado: EstadoLiquidacion;
-  periodo: string;
-}
+import type { Liquidacion } from '../types/liquidacion';
 
 export const liquidacionesMock: Liquidacion[] = [
   {
@@ -16,7 +7,8 @@ export const liquidacionesMock: Liquidacion[] = [
     montoAsignado: 150000,
     montoGastado: 94500,
     estado: 'Pendiente',
-    periodo: 'Enero 2024'
+    periodo: 'Enero 2024',
+    descripcion: 'Liquidación trimestral de actividades culturales.'
   },
   {
     id: 'LQ-2024-002',
@@ -24,7 +16,8 @@ export const liquidacionesMock: Liquidacion[] = [
     montoAsignado: 98000,
     montoGastado: 102500,
     estado: 'En Revisión',
-    periodo: 'Febrero 2024'
+    periodo: 'Febrero 2024',
+    descripcion: 'Gastos operativos y programas de ayuda social.'
   },
   {
     id: 'LQ-2024-003',
@@ -32,7 +25,8 @@ export const liquidacionesMock: Liquidacion[] = [
     montoAsignado: 200000,
     montoGastado: 198450,
     estado: 'Aprobada',
-    periodo: 'Marzo 2024'
+    periodo: 'Marzo 2024',
+    descripcion: 'Financiamiento de proyectos agrícolas.'
   },
   {
     id: 'LQ-2024-004',
@@ -40,6 +34,7 @@ export const liquidacionesMock: Liquidacion[] = [
     montoAsignado: 75000,
     montoGastado: 81200,
     estado: 'Rechazada',
-    periodo: 'Abril 2024'
+    periodo: 'Abril 2024',
+    descripcion: 'Organización de torneos juveniles.'
   }
 ];

--- a/src/features/liquidaciones/mock/liquidacionesData.ts
+++ b/src/features/liquidaciones/mock/liquidacionesData.ts
@@ -1,0 +1,45 @@
+export type EstadoLiquidacion = 'Pendiente' | 'En Revisión' | 'Aprobada' | 'Rechazada';
+
+export interface Liquidacion {
+  id: string;
+  asociacion: string;
+  montoAsignado: number;
+  montoGastado: number;
+  estado: EstadoLiquidacion;
+  periodo: string;
+}
+
+export const liquidacionesMock: Liquidacion[] = [
+  {
+    id: 'LQ-2024-001',
+    asociacion: 'Asociación Cultural Horizonte',
+    montoAsignado: 150000,
+    montoGastado: 94500,
+    estado: 'Pendiente',
+    periodo: 'Enero 2024'
+  },
+  {
+    id: 'LQ-2024-002',
+    asociacion: 'Fundación Manos Unidas',
+    montoAsignado: 98000,
+    montoGastado: 102500,
+    estado: 'En Revisión',
+    periodo: 'Febrero 2024'
+  },
+  {
+    id: 'LQ-2024-003',
+    asociacion: 'Cooperativa Nueva Esperanza',
+    montoAsignado: 200000,
+    montoGastado: 198450,
+    estado: 'Aprobada',
+    periodo: 'Marzo 2024'
+  },
+  {
+    id: 'LQ-2024-004',
+    asociacion: 'Asociación Deportiva Futuro',
+    montoAsignado: 75000,
+    montoGastado: 81200,
+    estado: 'Rechazada',
+    periodo: 'Abril 2024'
+  }
+];

--- a/src/features/liquidaciones/pages/LiquidacionesPage.tsx
+++ b/src/features/liquidaciones/pages/LiquidacionesPage.tsx
@@ -1,0 +1,20 @@
+import { LiquidacionesFiltros } from '../components/LiquidacionesFiltros';
+import { LiquidacionesHeader } from '../components/LiquidacionesHeader';
+import { LiquidacionesResumen } from '../components/LiquidacionesResumen';
+import { LiquidacionesTable } from '../components/LiquidacionesTable';
+import { NuevaLiquidacionModal } from '../components/NuevaLiquidacionModal';
+import { useLiquidaciones } from '../hooks/useLiquidaciones';
+
+export const LiquidacionesPage = () => {
+  const { liquidaciones, resumen } = useLiquidaciones();
+
+  return (
+    <section className="space-y-6">
+      <LiquidacionesHeader />
+      <LiquidacionesResumen {...resumen} />
+      <LiquidacionesFiltros />
+      <LiquidacionesTable data={liquidaciones} />
+      <NuevaLiquidacionModal />
+    </section>
+  );
+};

--- a/src/features/liquidaciones/pages/LiquidacionesPage.tsx
+++ b/src/features/liquidaciones/pages/LiquidacionesPage.tsx
@@ -6,14 +6,19 @@ import { NuevaLiquidacionModal } from '../components/NuevaLiquidacionModal';
 import { useLiquidaciones } from '../hooks/useLiquidaciones';
 
 export const LiquidacionesPage = () => {
-  const { liquidaciones, resumen } = useLiquidaciones();
+  const { liquidaciones, resumen, fetchState } = useLiquidaciones({ autoFetch: true });
 
   return (
     <section className="space-y-6">
       <LiquidacionesHeader />
-      <LiquidacionesResumen {...resumen} />
+      <LiquidacionesResumen {...resumen} isLoading={fetchState.status === 'loading'} />
       <LiquidacionesFiltros />
-      <LiquidacionesTable data={liquidaciones} />
+      {fetchState.status === 'error' && (
+        <div className="alert alert-error">
+          <span>{fetchState.error ?? 'Ocurrió un problema al obtener las liquidaciones. Inténtalo nuevamente.'}</span>
+        </div>
+      )}
+      <LiquidacionesTable data={liquidaciones} isLoading={fetchState.status === 'loading'} />
       <NuevaLiquidacionModal />
     </section>
   );

--- a/src/features/liquidaciones/services/liquidaciones.service.ts
+++ b/src/features/liquidaciones/services/liquidaciones.service.ts
@@ -1,13 +1,21 @@
 import { axiosClient } from '../../../services/httpClient';
-import type { Liquidacion } from '../mock/liquidacionesData';
+import type {
+  ActualizarLiquidacionPayload,
+  Liquidacion,
+  NuevaLiquidacionPayload
+} from '../types/liquidacion';
 
 export const liquidacionesService = {
   listar: async () => {
     const response = await axiosClient.get<Liquidacion[]>('/liquidaciones');
     return response.data;
   },
-  crear: async (payload: Partial<Liquidacion>) => {
+  crear: async (payload: NuevaLiquidacionPayload) => {
     const response = await axiosClient.post<Liquidacion>('/liquidaciones', payload);
+    return response.data;
+  },
+  actualizar: async (id: Liquidacion['id'], payload: ActualizarLiquidacionPayload) => {
+    const response = await axiosClient.put<Liquidacion>(`/liquidaciones/${id}`, payload);
     return response.data;
   }
 };

--- a/src/features/liquidaciones/services/liquidaciones.service.ts
+++ b/src/features/liquidaciones/services/liquidaciones.service.ts
@@ -1,0 +1,13 @@
+import { axiosClient } from '../../../services/httpClient';
+import type { Liquidacion } from '../mock/liquidacionesData';
+
+export const liquidacionesService = {
+  listar: async () => {
+    const response = await axiosClient.get<Liquidacion[]>('/liquidaciones');
+    return response.data;
+  },
+  crear: async (payload: Partial<Liquidacion>) => {
+    const response = await axiosClient.post<Liquidacion>('/liquidaciones', payload);
+    return response.data;
+  }
+};

--- a/src/features/liquidaciones/stores/liquidaciones.store.ts
+++ b/src/features/liquidaciones/stores/liquidaciones.store.ts
@@ -1,17 +1,82 @@
 import { create } from 'zustand';
 
-import type { Liquidacion } from '../mock/liquidacionesData';
-import { liquidacionesMock } from '../mock/liquidacionesData';
+import { getErrorMessage } from '../../../utils/error';
+import { liquidacionesService } from '../services/liquidaciones.service';
+import type {
+  ActualizarLiquidacionPayload,
+  Liquidacion,
+  NuevaLiquidacionPayload
+} from '../types/liquidacion';
+
+interface AsyncState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  error: string | null;
+}
+
+const createAsyncIdleState = (): AsyncState => ({ status: 'idle', error: null });
 
 interface LiquidacionesState {
   liquidaciones: Liquidacion[];
+  fetchState: AsyncState;
+  mutationState: AsyncState;
   mostrarModalNueva: boolean;
   toggleModalNueva: (mostrar?: boolean) => void;
+  fetchLiquidaciones: () => Promise<void>;
+  crearLiquidacion: (payload: NuevaLiquidacionPayload) => Promise<Liquidacion | undefined>;
+  actualizarLiquidacion: (
+    id: Liquidacion['id'],
+    payload: ActualizarLiquidacionPayload
+  ) => Promise<Liquidacion | undefined>;
 }
 
 export const useLiquidacionesStore = create<LiquidacionesState>((set) => ({
-  liquidaciones: liquidacionesMock,
+  liquidaciones: [],
+  fetchState: createAsyncIdleState(),
+  mutationState: createAsyncIdleState(),
   mostrarModalNueva: false,
   toggleModalNueva: (mostrar) =>
-    set((state) => ({ mostrarModalNueva: mostrar ?? !state.mostrarModalNueva }))
+    set((state) => ({
+      mostrarModalNueva: mostrar ?? !state.mostrarModalNueva,
+      mutationState: mostrar ? state.mutationState : createAsyncIdleState()
+    })),
+  fetchLiquidaciones: async () => {
+    set({ fetchState: { status: 'loading', error: null } });
+    try {
+      const data = await liquidacionesService.listar();
+      set({ liquidaciones: data, fetchState: { status: 'success', error: null } });
+    } catch (error) {
+      set({ fetchState: { status: 'error', error: getErrorMessage(error) } });
+    }
+  },
+  crearLiquidacion: async (payload) => {
+    set({ mutationState: { status: 'loading', error: null } });
+    try {
+      const nuevaLiquidacion = await liquidacionesService.crear(payload);
+      set((state) => ({
+        liquidaciones: [nuevaLiquidacion, ...state.liquidaciones],
+        mutationState: createAsyncIdleState(),
+        mostrarModalNueva: false
+      }));
+      return nuevaLiquidacion;
+    } catch (error) {
+      set({ mutationState: { status: 'error', error: getErrorMessage(error) } });
+      return undefined;
+    }
+  },
+  actualizarLiquidacion: async (id, payload) => {
+    set({ mutationState: { status: 'loading', error: null } });
+    try {
+      const liquidacionActualizada = await liquidacionesService.actualizar(id, payload);
+      set((state) => ({
+        liquidaciones: state.liquidaciones.map((item) =>
+          item.id === id ? liquidacionActualizada : item
+        ),
+        mutationState: { status: 'success', error: null }
+      }));
+      return liquidacionActualizada;
+    } catch (error) {
+      set({ mutationState: { status: 'error', error: getErrorMessage(error) } });
+      return undefined;
+    }
+  }
 }));

--- a/src/features/liquidaciones/stores/liquidaciones.store.ts
+++ b/src/features/liquidaciones/stores/liquidaciones.store.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+import type { Liquidacion } from '../mock/liquidacionesData';
+import { liquidacionesMock } from '../mock/liquidacionesData';
+
+interface LiquidacionesState {
+  liquidaciones: Liquidacion[];
+  mostrarModalNueva: boolean;
+  toggleModalNueva: (mostrar?: boolean) => void;
+}
+
+export const useLiquidacionesStore = create<LiquidacionesState>((set) => ({
+  liquidaciones: liquidacionesMock,
+  mostrarModalNueva: false,
+  toggleModalNueva: (mostrar) =>
+    set((state) => ({ mostrarModalNueva: mostrar ?? !state.mostrarModalNueva }))
+}));

--- a/src/features/liquidaciones/types/liquidacion.ts
+++ b/src/features/liquidaciones/types/liquidacion.ts
@@ -1,0 +1,29 @@
+export type EstadoLiquidacion = 'Pendiente' | 'En Revisión' | 'Aprobada' | 'Rechazada';
+
+export interface Liquidacion {
+  id: string;
+  asociacion: string;
+  periodo: string;
+  montoAsignado: number;
+  montoGastado: number;
+  estado: EstadoLiquidacion;
+  descripcion?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface NuevaLiquidacionPayload {
+  asociacion: string;
+  periodo: string;
+  montoAsignado: number;
+  montoGastado?: number;
+  descripcion?: string;
+  estado?: EstadoLiquidacion;
+}
+
+export interface ActualizarLiquidacionPayload {
+  montoAsignado?: number;
+  montoGastado?: number;
+  estado?: EstadoLiquidacion;
+  descripcion?: string;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-base-200 text-base-content;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,10 +11,19 @@ if (!rootElement) {
   throw new Error('Root element not found');
 }
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>
-);
+const bootstrap = async () => {
+  if (import.meta.env.DEV) {
+    const { setupHttpMocks } = await import('./mocks/http');
+    setupHttpMocks();
+  }
+
+  createRoot(rootElement).render(
+    <StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </StrictMode>
+  );
+};
+
+void bootstrap();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/src/mocks/http.ts
+++ b/src/mocks/http.ts
@@ -1,0 +1,99 @@
+import AxiosMockAdapter from 'axios-mock-adapter';
+
+import { liquidacionesMock } from '../features/liquidaciones/mock/liquidacionesData';
+import type {
+  Liquidacion,
+  NuevaLiquidacionPayload,
+  ActualizarLiquidacionPayload
+} from '../features/liquidaciones/types/liquidacion';
+import { axiosClient } from '../services/httpClient';
+
+let liquidacionesDb: Liquidacion[] = [...liquidacionesMock];
+
+const generateLiquidacionId = () => {
+  const consecutivo = (liquidacionesDb.length + 1).toString().padStart(3, '0');
+  const year = new Date().getFullYear();
+  return `LQ-${year}-${consecutivo}`;
+};
+
+const normalizeLiquidacion = (
+  data: NuevaLiquidacionPayload,
+  overrides?: Partial<Liquidacion>
+): Liquidacion => ({
+  id: overrides?.id ?? generateLiquidacionId(),
+  asociacion: data.asociacion,
+  periodo: data.periodo,
+  montoAsignado: Number(data.montoAsignado),
+  montoGastado: Number(data.montoGastado ?? 0),
+  estado: data.estado ?? 'Pendiente',
+  descripcion: data.descripcion,
+  createdAt: overrides?.createdAt ?? new Date().toISOString(),
+  updatedAt: overrides?.updatedAt ?? new Date().toISOString()
+});
+
+export const setupHttpMocks = () => {
+  const mock = new AxiosMockAdapter(axiosClient, { delayResponse: 600 });
+
+  mock.onGet('/liquidaciones').reply(() => [200, liquidacionesDb]);
+
+  mock.onPost('/liquidaciones').reply((config) => {
+    if (!config.data) {
+      return [400, { message: 'Solicitud inválida' }];
+    }
+
+    const payload = JSON.parse(config.data) as NuevaLiquidacionPayload;
+
+    if (
+      !payload.asociacion ||
+      !payload.periodo ||
+      typeof payload.montoAsignado === 'undefined'
+    ) {
+      return [422, { message: 'Faltan datos requeridos para registrar la liquidación.' }];
+    }
+
+    const nuevaLiquidacion = normalizeLiquidacion(payload);
+    liquidacionesDb = [nuevaLiquidacion, ...liquidacionesDb];
+
+    return [201, nuevaLiquidacion];
+  });
+
+  mock.onPut(/\/liquidaciones\/[^/]+$/).reply((config) => {
+    if (!config.url) {
+      return [400, { message: 'Solicitud inválida' }];
+    }
+
+    const id = config.url.split('/').pop() as string;
+    const liquidacion = liquidacionesDb.find((item) => item.id === id);
+
+    if (!liquidacion) {
+      return [404, { message: 'La liquidación indicada no existe.' }];
+    }
+
+    const payload = config.data ? (JSON.parse(config.data) as ActualizarLiquidacionPayload) : {};
+
+    const liquidacionActualizada: Liquidacion = {
+      ...liquidacion,
+      montoAsignado:
+        typeof payload.montoAsignado !== 'undefined'
+          ? Number(payload.montoAsignado)
+          : liquidacion.montoAsignado,
+      montoGastado:
+        typeof payload.montoGastado !== 'undefined'
+          ? Number(payload.montoGastado)
+          : liquidacion.montoGastado,
+      estado: payload.estado ?? liquidacion.estado,
+      descripcion: payload.descripcion ?? liquidacion.descripcion,
+      updatedAt: new Date().toISOString()
+    };
+
+    liquidacionesDb = liquidacionesDb.map((item) => (item.id === id ? liquidacionActualizada : item));
+
+    return [200, liquidacionActualizada];
+  });
+
+  return mock;
+};
+
+export const resetHttpMocks = () => {
+  liquidacionesDb = [...liquidacionesMock];
+};

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+export const axiosClient = axios.create({
+  baseURL: 'https://api.mi-organizacion.test',
+  headers: {
+    'Content-Type': 'application/json'
+  }
+});
+
+axiosClient.interceptors.request.use((config) => {
+  // Aquí podremos inyectar token de autenticación en futuras fases
+  return config;
+});
+
+axiosClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // Placeholder para manejo de errores centralizados en fases posteriores
+    return Promise.reject(error);
+  }
+);

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,9 +1,12 @@
 import axios from 'axios';
 
+const baseURL = import.meta.env.VITE_API_URL ?? 'https://api.mi-organizacion.test';
+
 export const axiosClient = axios.create({
-  baseURL: 'https://api.mi-organizacion.test',
+  baseURL,
   headers: {
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
   }
 });
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,29 @@
+import { isAxiosError } from 'axios';
+
+interface ErrorWithMessage {
+  message: string;
+}
+
+const isErrorWithMessage = (error: unknown): error is ErrorWithMessage => {
+  return typeof error === 'object' && error !== null && 'message' in error;
+};
+
+export const getErrorMessage = (error: unknown): string => {
+  if (isAxiosError(error)) {
+    const apiMessage = error.response?.data?.message;
+    if (typeof apiMessage === 'string') {
+      return apiMessage;
+    }
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (isErrorWithMessage(error) && typeof error.message === 'string') {
+    return error.message;
+  }
+
+  return 'Ha ocurrido un error inesperado. Inténtalo nuevamente.';
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss';
+import daisyui from 'daisyui';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: [daisyui]
+} satisfies Config;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- initialize Vite + React 19 workspace with TailwindCSS and DaisyUI for the liquidaciones module
- scaffold feature-based structure for liquidaciones including mock data, Zustand store, and service placeholders
- implement static liquidaciones page with resumen, filtros, tabla y modal de nueva liquidación

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd3b08eb58832e8df3dad7599eb3ba